### PR TITLE
Distinct publisher coverage TSV & sluggify

### DIFF
--- a/06.visualize-coverage.ipynb
+++ b/06.visualize-coverage.ipynb
@@ -188,67 +188,8 @@
        "<table>\n",
        "<thead><tr><th scope=col>scopus_id</th><th scope=col>title_name</th><th scope=col>active</th><th scope=col>open_access</th><th scope=col>scihub</th><th scope=col>crossref</th><th scope=col>coverage</th></tr></thead>\n",
        "<tbody>\n",
-       "\t<tr><td>18607                                                    </td><td>Primary Care Respiratory Journal                         </td><td>0                                                        </td><td>1                                                        </td><td>469                                                      </td><td>1259                                                     </td><td>0.3725200                                                </td></tr>\n",
-       "\t<tr><td>18889                                                    </td><td>Indian Journal of Human Genetics                         </td><td>0                                                        </td><td>1                                                        </td><td>347                                                      </td><td> 475                                                     </td><td>0.7305300                                                </td></tr>\n",
-       "\t<tr><td>19523                                                    </td><td>Bulletin of the Veterinary Institute in Pulawy           </td><td>0                                                        </td><td>1                                                        </td><td>117                                                      </td><td> 232                                                     </td><td>0.5043100                                                </td></tr>\n",
-       "\t<tr><td>19555                                                    </td><td>Veterinary Research                                      </td><td>0                                                        </td><td>1                                                        </td><td>757                                                      </td><td>1507                                                     </td><td>0.5023200                                                </td></tr>\n",
-       "\t<tr><td>20353                                                    </td><td>South African Journal of Wildlife Research               </td><td>0                                                        </td><td>1                                                        </td><td>196                                                      </td><td> 198                                                     </td><td>0.9899000                                                </td></tr>\n",
-       "\t<tr><td>21991                                                    </td><td>New South Wales public health bulletin                   </td><td>0                                                        </td><td>1                                                        </td><td> 36                                                      </td><td>1815                                                     </td><td>0.0198350                                                </td></tr>\n",
-       "\t<tr><td>23684                                                    </td><td>Informatics in Primary Care                              </td><td>0                                                        </td><td>1                                                        </td><td>  0                                                      </td><td>  27                                                     </td><td>0.0000000                                                </td></tr>\n",
-       "\t<tr><td>24557                                                    </td><td>Mathematical and Computational Applications              </td><td>0                                                        </td><td>1                                                        </td><td>  0                                                      </td><td> 843                                                     </td><td>0.0000000                                                </td></tr>\n",
-       "\t<tr><td>26700                                                    </td><td>Revista Argentina de Endocrinologia y Metabolismo        </td><td>0                                                        </td><td>1                                                        </td><td> 30                                                      </td><td>  34                                                     </td><td>0.8823500                                                </td></tr>\n",
-       "\t<tr><td>38536                                                    </td><td>Turk Serebrovaskuler Hastaliklar Dergisi                 </td><td>0                                                        </td><td>1                                                        </td><td>  0                                                      </td><td> 106                                                     </td><td>0.0000000                                                </td></tr>\n",
-       "\t<tr><td>130093                                                   </td><td>Biogeosciences Discussions                               </td><td>0                                                        </td><td>1                                                        </td><td> 46                                                      </td><td>3989                                                     </td><td>0.0115320                                                </td></tr>\n",
-       "\t<tr><td>5100152606                                               </td><td>Biosciences Biotechnology Research Asia                  </td><td>0                                                        </td><td>1                                                        </td><td>  8                                                      </td><td>1646                                                     </td><td>0.0048603                                                </td></tr>\n",
-       "\t<tr><td>5400152617                                               </td><td>American Journal of Environmental Sciences               </td><td>0                                                        </td><td>1                                                        </td><td>  2                                                      </td><td> 756                                                     </td><td>0.0026455                                                </td></tr>\n",
-       "\t<tr><td>5400152637                                               </td><td>American Journal of Infectious Diseases                  </td><td>0                                                        </td><td>1                                                        </td><td>  1                                                      </td><td> 344                                                     </td><td>0.0029070                                                </td></tr>\n",
-       "\t<tr><td>5800179602                                               </td><td>Scoliosis                                                </td><td>0                                                        </td><td>1                                                        </td><td>769                                                      </td><td> 970                                                     </td><td>0.7927800                                                </td></tr>\n",
-       "\t<tr><td>6400153122                                               </td><td>American Journal of Applied Sciences                     </td><td>0                                                        </td><td>1                                                        </td><td> 29                                                      </td><td>2719                                                     </td><td>0.0106660                                                </td></tr>\n",
-       "\t<tr><td>6400153145                                               </td><td>Cough                                                    </td><td>0                                                        </td><td>1                                                        </td><td>119                                                      </td><td> 121                                                     </td><td>0.9834700                                                </td></tr>\n",
-       "\t<tr><td>7400153105                                               </td><td>Journal of Mathematics and Statistics                    </td><td>0                                                        </td><td>1                                                        </td><td>  6                                                      </td><td> 616                                                     </td><td>0.0097403                                                </td></tr>\n",
-       "\t<tr><td>8300153132                                               </td><td>American Journal of Agricultural and Biological Science  </td><td>0                                                        </td><td>1                                                        </td><td> 11                                                      </td><td> 530                                                     </td><td>0.0207550                                                </td></tr>\n",
-       "\t<tr><td>10400153308                                              </td><td>American Journal of Immunology                           </td><td>0                                                        </td><td>1                                                        </td><td>  0                                                      </td><td> 196                                                     </td><td>0.0000000                                                </td></tr>\n",
-       "\t<tr><td>11400153336                                              </td><td>Estonian Journal of Ecology                              </td><td>0                                                        </td><td>1                                                        </td><td>136                                                      </td><td> 152                                                     </td><td>0.8947400                                                </td></tr>\n",
-       "\t<tr><td>12100155654                                              </td><td>Biomedical Imaging and Intervention Journal              </td><td>0                                                        </td><td>1                                                        </td><td> 54                                                      </td><td> 256                                                     </td><td>0.2109400                                                </td></tr>\n",
-       "\t<tr><td>16200154706                                              </td><td>Romanticism on the Net                                   </td><td>0                                                        </td><td>1                                                        </td><td>  0                                                      </td><td> 511                                                     </td><td>0.0000000                                                </td></tr>\n",
-       "\t<tr><td>17200154704                                              </td><td>International Journal of Soft Computing                  </td><td>0                                                        </td><td>1                                                        </td><td>  0                                                      </td><td> 106                                                     </td><td>0.0000000                                                </td></tr>\n",
-       "\t<tr><td>17600155016                                              </td><td>BMC Medical Physics                                      </td><td>0                                                        </td><td>1                                                        </td><td> 26                                                      </td><td>  26                                                     </td><td>1.0000000                                                </td></tr>\n",
-       "\t<tr><td>17600155057                                              </td><td>Living Reviews in Landscape Research                     </td><td>0                                                        </td><td>1                                                        </td><td>  5                                                      </td><td>  21                                                     </td><td>0.2381000                                                </td></tr>\n",
-       "\t<tr><td>17900156726                                              </td><td>Formalized Mathematics                                   </td><td>0                                                        </td><td>1                                                        </td><td> 91                                                      </td><td> 350                                                     </td><td>0.2600000                                                </td></tr>\n",
-       "\t<tr><td>19600157021                                              </td><td>Macedonian Journal of Medical Sciences                   </td><td>0                                                        </td><td>1                                                        </td><td> 54                                                      </td><td> 424                                                     </td><td>0.1273600                                                </td></tr>\n",
-       "\t<tr><td>19700166520                                              </td><td>Cases Journal                                            </td><td>0                                                        </td><td>1                                                        </td><td>625                                                      </td><td>1741                                                     </td><td>0.3589900                                                </td></tr>\n",
-       "\t<tr><td>19700174685                                              </td><td>Journal of Experimental Stroke and Translational Medicine</td><td>0                                                        </td><td>1                                                        </td><td>  0                                                      </td><td>  40                                                     </td><td>0.0000000                                                </td></tr>\n",
-       "\t<tr><td>⋮</td><td>⋮</td><td>⋮</td><td>⋮</td><td>⋮</td><td>⋮</td><td>⋮</td></tr>\n",
-       "\t<tr><td>21100197523                                                            </td><td>International Journal of Multimedia and Ubiquitous Engineering         </td><td>0                                                                      </td><td>1                                                                      </td><td>  6                                                                    </td><td>1484                                                                   </td><td>0.0040431                                                              </td></tr>\n",
-       "\t<tr><td>21100198717                                                            </td><td>Open Catalysis Journal                                                 </td><td>0                                                                      </td><td>1                                                                      </td><td>  0                                                                    </td><td>  80                                                                   </td><td>0.0000000                                                              </td></tr>\n",
-       "\t<tr><td>21100199112                                                            </td><td>International Journal of Security and its Applications                 </td><td>0                                                                      </td><td>1                                                                      </td><td>  5                                                                    </td><td>1141                                                                   </td><td>0.0043821                                                              </td></tr>\n",
-       "\t<tr><td>21100199850                                                            </td><td>International Journal of Software Engineering and its Applications     </td><td>0                                                                      </td><td>1                                                                      </td><td>  2                                                                    </td><td> 608                                                                   </td><td>0.0032895                                                              </td></tr>\n",
-       "\t<tr><td>21100200033                                                            </td><td>Frontiers in Neuroenergetics                                           </td><td>0                                                                      </td><td>1                                                                      </td><td>  2                                                                    </td><td>  71                                                                   </td><td>0.0281690                                                              </td></tr>\n",
-       "\t<tr><td>21100200204                                                            </td><td>Journal of Dental Biomechanics                                         </td><td>0                                                                      </td><td>1                                                                      </td><td> 13                                                                    </td><td>  37                                                                   </td><td>0.3513500                                                              </td></tr>\n",
-       "\t<tr><td>21100202936                                                            </td><td>Biology and Medicine                                                   </td><td>0                                                                      </td><td>1                                                                      </td><td>  1                                                                    </td><td> 229                                                                   </td><td>0.0043668                                                              </td></tr>\n",
-       "\t<tr><td>21100205766                                                            </td><td>Perspectives in Medicine                                               </td><td>0                                                                      </td><td>1                                                                      </td><td>123                                                                    </td><td> 123                                                                   </td><td>1.0000000                                                              </td></tr>\n",
-       "\t<tr><td>21100206606                                                            </td><td>Investigaciones Europeas de Direccion y Economia de la Empresa         </td><td>0                                                                      </td><td>1                                                                      </td><td>197                                                                    </td><td> 197                                                                   </td><td>1.0000000                                                              </td></tr>\n",
-       "\t<tr><td>21100211347                                                            </td><td>Trials in Vaccinology                                                  </td><td>0                                                                      </td><td>1                                                                      </td><td> 80                                                                    </td><td>  81                                                                   </td><td>0.9876500                                                              </td></tr>\n",
-       "\t<tr><td>21100220119                                                            </td><td>Korean Journal of Pediatric Infectious Diseases                        </td><td>0                                                                      </td><td>1                                                                      </td><td>  0                                                                    </td><td>  27                                                                   </td><td>0.0000000                                                              </td></tr>\n",
-       "\t<tr><td>21100220137                                                            </td><td>Bioscience Education                                                   </td><td>0                                                                      </td><td>1                                                                      </td><td>216                                                                    </td><td> 263                                                                   </td><td>0.8212900                                                              </td></tr>\n",
-       "\t<tr><td>21100223579                                                            </td><td>Advanced Materials Letters                                             </td><td>0                                                                      </td><td>1                                                                      </td><td> 52                                                                    </td><td> 907                                                                   </td><td>0.0573320                                                              </td></tr>\n",
-       "\t<tr><td>21100258399                                                            </td><td>Optical Nanoscopy                                                      </td><td>0                                                                      </td><td>1                                                                      </td><td> 19                                                                    </td><td>  20                                                                   </td><td>0.9500000                                                              </td></tr>\n",
-       "\t<tr><td>21100258967                                                            </td><td>ISRN Mechanical Engineering                                            </td><td>0                                                                      </td><td>1                                                                      </td><td>120                                                                    </td><td> 137                                                                   </td><td>0.8759100                                                              </td></tr>\n",
-       "\t<tr><td>21100264566                                                            </td><td>South Asian Journal of Cancer                                          </td><td>0                                                                      </td><td>1                                                                      </td><td>  4                                                                    </td><td> 403                                                                   </td><td>0.0099256                                                              </td></tr>\n",
-       "\t<tr><td>21100265048                                                            </td><td>Contemporary Engineering Sciences                                      </td><td>0                                                                      </td><td>1                                                                      </td><td>  9                                                                    </td><td> 616                                                                   </td><td>0.0146100                                                              </td></tr>\n",
-       "\t<tr><td>21100266906                                                            </td><td>ISRN Communications and Networking                                     </td><td>0                                                                      </td><td>1                                                                      </td><td>  8                                                                    </td><td>  67                                                                   </td><td>0.1194000                                                              </td></tr>\n",
-       "\t<tr><td>21100268208                                                            </td><td>Video Journal and Encyclopedia of GI Endoscopy                         </td><td>0                                                                      </td><td>1                                                                      </td><td>297                                                                    </td><td> 297                                                                   </td><td>1.0000000                                                              </td></tr>\n",
-       "\t<tr><td>21100293201                                                            </td><td>International Journal of Research in Ayurveda and Pharmacy             </td><td>0                                                                      </td><td>1                                                                      </td><td>  2                                                                    </td><td> 863                                                                   </td><td>0.0023175                                                              </td></tr>\n",
-       "\t<tr><td>21100386191                                                            </td><td>ISRN Signal Processing                                                 </td><td>0                                                                      </td><td>1                                                                      </td><td>  5                                                                    </td><td>  84                                                                   </td><td>0.0595240                                                              </td></tr>\n",
-       "\t<tr><td>21100386192                                                            </td><td>ISRN Civil Engineering                                                 </td><td>0                                                                      </td><td>1                                                                      </td><td> 60                                                                    </td><td>  71                                                                   </td><td>0.8450700                                                              </td></tr>\n",
-       "\t<tr><td>21100399105                                                            </td><td>Journal of Nonlinear Science and Applications                          </td><td>0                                                                      </td><td>1                                                                      </td><td>  0                                                                    </td><td> 111                                                                   </td><td>0.0000000                                                              </td></tr>\n",
-       "\t<tr><td>21100422125                                                            </td><td>International Journal of Applied Linguistics and English Literature    </td><td>0                                                                      </td><td>1                                                                      </td><td>  0                                                                    </td><td>1010                                                                   </td><td>0.0000000                                                              </td></tr>\n",
-       "\t<tr><td>21100432005                                                            </td><td>Journal of Signal Transduction                                         </td><td>0                                                                      </td><td>1                                                                      </td><td> 73                                                                    </td><td> 112                                                                   </td><td>0.6517900                                                              </td></tr>\n",
-       "\t<tr><td>21100437958                                                            </td><td>American Journal of Engineering and Applied Sciences                   </td><td>0                                                                      </td><td>1                                                                      </td><td>  2                                                                    </td><td> 658                                                                   </td><td>0.0030395                                                              </td></tr>\n",
-       "\t<tr><td>21100447121                                                            </td><td>International Journal of Future Generation Communication and Networking</td><td>0                                                                      </td><td>1                                                                      </td><td> 11                                                                    </td><td> 770                                                                   </td><td>0.0142860                                                              </td></tr>\n",
-       "\t<tr><td>21100456184                                                            </td><td>Applied Petrochemical Research                                         </td><td>0                                                                      </td><td>1                                                                      </td><td>172                                                                    </td><td> 174                                                                   </td><td>0.9885100                                                              </td></tr>\n",
-       "\t<tr><td>21100457107                                                            </td><td>SAGE Open Medicine                                                     </td><td>0                                                                      </td><td>1                                                                      </td><td>206                                                                    </td><td> 287                                                                   </td><td>0.7177700                                                              </td></tr>\n",
-       "\t<tr><td>21100464757                                                            </td><td>ISRN Dermatology                                                       </td><td>0                                                                      </td><td>1                                                                      </td><td> 96                                                                    </td><td> 100                                                                   </td><td>0.9600000                                                              </td></tr>\n",
+       "\t<tr><td>18607                           </td><td>Primary Care Respiratory Journal</td><td>0                               </td><td>1                               </td><td>469                             </td><td>1259                            </td><td>0.37252                         </td></tr>\n",
+       "\t<tr><td>18889                           </td><td>Indian Journal of Human Genetics</td><td>0                               </td><td>1                               </td><td>347                             </td><td> 475                            </td><td>0.73053                         </td></tr>\n",
        "</tbody>\n",
        "</table>\n"
       ],
@@ -256,324 +197,26 @@
        "\\begin{tabular}{r|lllllll}\n",
        " scopus\\_id & title\\_name & active & open\\_access & scihub & crossref & coverage\\\\\n",
        "\\hline\n",
-       "\t 18607                                                     & Primary Care Respiratory Journal                          & 0                                                         & 1                                                         & 469                                                       & 1259                                                      & 0.3725200                                                \\\\\n",
-       "\t 18889                                                     & Indian Journal of Human Genetics                          & 0                                                         & 1                                                         & 347                                                       &  475                                                      & 0.7305300                                                \\\\\n",
-       "\t 19523                                                     & Bulletin of the Veterinary Institute in Pulawy            & 0                                                         & 1                                                         & 117                                                       &  232                                                      & 0.5043100                                                \\\\\n",
-       "\t 19555                                                     & Veterinary Research                                       & 0                                                         & 1                                                         & 757                                                       & 1507                                                      & 0.5023200                                                \\\\\n",
-       "\t 20353                                                     & South African Journal of Wildlife Research                & 0                                                         & 1                                                         & 196                                                       &  198                                                      & 0.9899000                                                \\\\\n",
-       "\t 21991                                                     & New South Wales public health bulletin                    & 0                                                         & 1                                                         &  36                                                       & 1815                                                      & 0.0198350                                                \\\\\n",
-       "\t 23684                                                     & Informatics in Primary Care                               & 0                                                         & 1                                                         &   0                                                       &   27                                                      & 0.0000000                                                \\\\\n",
-       "\t 24557                                                     & Mathematical and Computational Applications               & 0                                                         & 1                                                         &   0                                                       &  843                                                      & 0.0000000                                                \\\\\n",
-       "\t 26700                                                     & Revista Argentina de Endocrinologia y Metabolismo         & 0                                                         & 1                                                         &  30                                                       &   34                                                      & 0.8823500                                                \\\\\n",
-       "\t 38536                                                     & Turk Serebrovaskuler Hastaliklar Dergisi                  & 0                                                         & 1                                                         &   0                                                       &  106                                                      & 0.0000000                                                \\\\\n",
-       "\t 130093                                                    & Biogeosciences Discussions                                & 0                                                         & 1                                                         &  46                                                       & 3989                                                      & 0.0115320                                                \\\\\n",
-       "\t 5100152606                                                & Biosciences Biotechnology Research Asia                   & 0                                                         & 1                                                         &   8                                                       & 1646                                                      & 0.0048603                                                \\\\\n",
-       "\t 5400152617                                                & American Journal of Environmental Sciences                & 0                                                         & 1                                                         &   2                                                       &  756                                                      & 0.0026455                                                \\\\\n",
-       "\t 5400152637                                                & American Journal of Infectious Diseases                   & 0                                                         & 1                                                         &   1                                                       &  344                                                      & 0.0029070                                                \\\\\n",
-       "\t 5800179602                                                & Scoliosis                                                 & 0                                                         & 1                                                         & 769                                                       &  970                                                      & 0.7927800                                                \\\\\n",
-       "\t 6400153122                                                & American Journal of Applied Sciences                      & 0                                                         & 1                                                         &  29                                                       & 2719                                                      & 0.0106660                                                \\\\\n",
-       "\t 6400153145                                                & Cough                                                     & 0                                                         & 1                                                         & 119                                                       &  121                                                      & 0.9834700                                                \\\\\n",
-       "\t 7400153105                                                & Journal of Mathematics and Statistics                     & 0                                                         & 1                                                         &   6                                                       &  616                                                      & 0.0097403                                                \\\\\n",
-       "\t 8300153132                                                & American Journal of Agricultural and Biological Science   & 0                                                         & 1                                                         &  11                                                       &  530                                                      & 0.0207550                                                \\\\\n",
-       "\t 10400153308                                               & American Journal of Immunology                            & 0                                                         & 1                                                         &   0                                                       &  196                                                      & 0.0000000                                                \\\\\n",
-       "\t 11400153336                                               & Estonian Journal of Ecology                               & 0                                                         & 1                                                         & 136                                                       &  152                                                      & 0.8947400                                                \\\\\n",
-       "\t 12100155654                                               & Biomedical Imaging and Intervention Journal               & 0                                                         & 1                                                         &  54                                                       &  256                                                      & 0.2109400                                                \\\\\n",
-       "\t 16200154706                                               & Romanticism on the Net                                    & 0                                                         & 1                                                         &   0                                                       &  511                                                      & 0.0000000                                                \\\\\n",
-       "\t 17200154704                                               & International Journal of Soft Computing                   & 0                                                         & 1                                                         &   0                                                       &  106                                                      & 0.0000000                                                \\\\\n",
-       "\t 17600155016                                               & BMC Medical Physics                                       & 0                                                         & 1                                                         &  26                                                       &   26                                                      & 1.0000000                                                \\\\\n",
-       "\t 17600155057                                               & Living Reviews in Landscape Research                      & 0                                                         & 1                                                         &   5                                                       &   21                                                      & 0.2381000                                                \\\\\n",
-       "\t 17900156726                                               & Formalized Mathematics                                    & 0                                                         & 1                                                         &  91                                                       &  350                                                      & 0.2600000                                                \\\\\n",
-       "\t 19600157021                                               & Macedonian Journal of Medical Sciences                    & 0                                                         & 1                                                         &  54                                                       &  424                                                      & 0.1273600                                                \\\\\n",
-       "\t 19700166520                                               & Cases Journal                                             & 0                                                         & 1                                                         & 625                                                       & 1741                                                      & 0.3589900                                                \\\\\n",
-       "\t 19700174685                                               & Journal of Experimental Stroke and Translational Medicine & 0                                                         & 1                                                         &   0                                                       &   40                                                      & 0.0000000                                                \\\\\n",
-       "\t ⋮ & ⋮ & ⋮ & ⋮ & ⋮ & ⋮ & ⋮\\\\\n",
-       "\t 21100197523                                                             & International Journal of Multimedia and Ubiquitous Engineering          & 0                                                                       & 1                                                                       &   6                                                                     & 1484                                                                    & 0.0040431                                                              \\\\\n",
-       "\t 21100198717                                                             & Open Catalysis Journal                                                  & 0                                                                       & 1                                                                       &   0                                                                     &   80                                                                    & 0.0000000                                                              \\\\\n",
-       "\t 21100199112                                                             & International Journal of Security and its Applications                  & 0                                                                       & 1                                                                       &   5                                                                     & 1141                                                                    & 0.0043821                                                              \\\\\n",
-       "\t 21100199850                                                             & International Journal of Software Engineering and its Applications      & 0                                                                       & 1                                                                       &   2                                                                     &  608                                                                    & 0.0032895                                                              \\\\\n",
-       "\t 21100200033                                                             & Frontiers in Neuroenergetics                                            & 0                                                                       & 1                                                                       &   2                                                                     &   71                                                                    & 0.0281690                                                              \\\\\n",
-       "\t 21100200204                                                             & Journal of Dental Biomechanics                                          & 0                                                                       & 1                                                                       &  13                                                                     &   37                                                                    & 0.3513500                                                              \\\\\n",
-       "\t 21100202936                                                             & Biology and Medicine                                                    & 0                                                                       & 1                                                                       &   1                                                                     &  229                                                                    & 0.0043668                                                              \\\\\n",
-       "\t 21100205766                                                             & Perspectives in Medicine                                                & 0                                                                       & 1                                                                       & 123                                                                     &  123                                                                    & 1.0000000                                                              \\\\\n",
-       "\t 21100206606                                                             & Investigaciones Europeas de Direccion y Economia de la Empresa          & 0                                                                       & 1                                                                       & 197                                                                     &  197                                                                    & 1.0000000                                                              \\\\\n",
-       "\t 21100211347                                                             & Trials in Vaccinology                                                   & 0                                                                       & 1                                                                       &  80                                                                     &   81                                                                    & 0.9876500                                                              \\\\\n",
-       "\t 21100220119                                                             & Korean Journal of Pediatric Infectious Diseases                         & 0                                                                       & 1                                                                       &   0                                                                     &   27                                                                    & 0.0000000                                                              \\\\\n",
-       "\t 21100220137                                                             & Bioscience Education                                                    & 0                                                                       & 1                                                                       & 216                                                                     &  263                                                                    & 0.8212900                                                              \\\\\n",
-       "\t 21100223579                                                             & Advanced Materials Letters                                              & 0                                                                       & 1                                                                       &  52                                                                     &  907                                                                    & 0.0573320                                                              \\\\\n",
-       "\t 21100258399                                                             & Optical Nanoscopy                                                       & 0                                                                       & 1                                                                       &  19                                                                     &   20                                                                    & 0.9500000                                                              \\\\\n",
-       "\t 21100258967                                                             & ISRN Mechanical Engineering                                             & 0                                                                       & 1                                                                       & 120                                                                     &  137                                                                    & 0.8759100                                                              \\\\\n",
-       "\t 21100264566                                                             & South Asian Journal of Cancer                                           & 0                                                                       & 1                                                                       &   4                                                                     &  403                                                                    & 0.0099256                                                              \\\\\n",
-       "\t 21100265048                                                             & Contemporary Engineering Sciences                                       & 0                                                                       & 1                                                                       &   9                                                                     &  616                                                                    & 0.0146100                                                              \\\\\n",
-       "\t 21100266906                                                             & ISRN Communications and Networking                                      & 0                                                                       & 1                                                                       &   8                                                                     &   67                                                                    & 0.1194000                                                              \\\\\n",
-       "\t 21100268208                                                             & Video Journal and Encyclopedia of GI Endoscopy                          & 0                                                                       & 1                                                                       & 297                                                                     &  297                                                                    & 1.0000000                                                              \\\\\n",
-       "\t 21100293201                                                             & International Journal of Research in Ayurveda and Pharmacy              & 0                                                                       & 1                                                                       &   2                                                                     &  863                                                                    & 0.0023175                                                              \\\\\n",
-       "\t 21100386191                                                             & ISRN Signal Processing                                                  & 0                                                                       & 1                                                                       &   5                                                                     &   84                                                                    & 0.0595240                                                              \\\\\n",
-       "\t 21100386192                                                             & ISRN Civil Engineering                                                  & 0                                                                       & 1                                                                       &  60                                                                     &   71                                                                    & 0.8450700                                                              \\\\\n",
-       "\t 21100399105                                                             & Journal of Nonlinear Science and Applications                           & 0                                                                       & 1                                                                       &   0                                                                     &  111                                                                    & 0.0000000                                                              \\\\\n",
-       "\t 21100422125                                                             & International Journal of Applied Linguistics and English Literature     & 0                                                                       & 1                                                                       &   0                                                                     & 1010                                                                    & 0.0000000                                                              \\\\\n",
-       "\t 21100432005                                                             & Journal of Signal Transduction                                          & 0                                                                       & 1                                                                       &  73                                                                     &  112                                                                    & 0.6517900                                                              \\\\\n",
-       "\t 21100437958                                                             & American Journal of Engineering and Applied Sciences                    & 0                                                                       & 1                                                                       &   2                                                                     &  658                                                                    & 0.0030395                                                              \\\\\n",
-       "\t 21100447121                                                             & International Journal of Future Generation Communication and Networking & 0                                                                       & 1                                                                       &  11                                                                     &  770                                                                    & 0.0142860                                                              \\\\\n",
-       "\t 21100456184                                                             & Applied Petrochemical Research                                          & 0                                                                       & 1                                                                       & 172                                                                     &  174                                                                    & 0.9885100                                                              \\\\\n",
-       "\t 21100457107                                                             & SAGE Open Medicine                                                      & 0                                                                       & 1                                                                       & 206                                                                     &  287                                                                    & 0.7177700                                                              \\\\\n",
-       "\t 21100464757                                                             & ISRN Dermatology                                                        & 0                                                                       & 1                                                                       &  96                                                                     &  100                                                                    & 0.9600000                                                              \\\\\n",
+       "\t 18607                            & Primary Care Respiratory Journal & 0                                & 1                                & 469                              & 1259                             & 0.37252                         \\\\\n",
+       "\t 18889                            & Indian Journal of Human Genetics & 0                                & 1                                & 347                              &  475                             & 0.73053                         \\\\\n",
        "\\end{tabular}\n"
       ],
       "text/markdown": [
        "\n",
        "scopus_id | title_name | active | open_access | scihub | crossref | coverage | \n",
-       "|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|\n",
-       "| 18607                                                     | Primary Care Respiratory Journal                          | 0                                                         | 1                                                         | 469                                                       | 1259                                                      | 0.3725200                                                 | \n",
-       "| 18889                                                     | Indian Journal of Human Genetics                          | 0                                                         | 1                                                         | 347                                                       |  475                                                      | 0.7305300                                                 | \n",
-       "| 19523                                                     | Bulletin of the Veterinary Institute in Pulawy            | 0                                                         | 1                                                         | 117                                                       |  232                                                      | 0.5043100                                                 | \n",
-       "| 19555                                                     | Veterinary Research                                       | 0                                                         | 1                                                         | 757                                                       | 1507                                                      | 0.5023200                                                 | \n",
-       "| 20353                                                     | South African Journal of Wildlife Research                | 0                                                         | 1                                                         | 196                                                       |  198                                                      | 0.9899000                                                 | \n",
-       "| 21991                                                     | New South Wales public health bulletin                    | 0                                                         | 1                                                         |  36                                                       | 1815                                                      | 0.0198350                                                 | \n",
-       "| 23684                                                     | Informatics in Primary Care                               | 0                                                         | 1                                                         |   0                                                       |   27                                                      | 0.0000000                                                 | \n",
-       "| 24557                                                     | Mathematical and Computational Applications               | 0                                                         | 1                                                         |   0                                                       |  843                                                      | 0.0000000                                                 | \n",
-       "| 26700                                                     | Revista Argentina de Endocrinologia y Metabolismo         | 0                                                         | 1                                                         |  30                                                       |   34                                                      | 0.8823500                                                 | \n",
-       "| 38536                                                     | Turk Serebrovaskuler Hastaliklar Dergisi                  | 0                                                         | 1                                                         |   0                                                       |  106                                                      | 0.0000000                                                 | \n",
-       "| 130093                                                    | Biogeosciences Discussions                                | 0                                                         | 1                                                         |  46                                                       | 3989                                                      | 0.0115320                                                 | \n",
-       "| 5100152606                                                | Biosciences Biotechnology Research Asia                   | 0                                                         | 1                                                         |   8                                                       | 1646                                                      | 0.0048603                                                 | \n",
-       "| 5400152617                                                | American Journal of Environmental Sciences                | 0                                                         | 1                                                         |   2                                                       |  756                                                      | 0.0026455                                                 | \n",
-       "| 5400152637                                                | American Journal of Infectious Diseases                   | 0                                                         | 1                                                         |   1                                                       |  344                                                      | 0.0029070                                                 | \n",
-       "| 5800179602                                                | Scoliosis                                                 | 0                                                         | 1                                                         | 769                                                       |  970                                                      | 0.7927800                                                 | \n",
-       "| 6400153122                                                | American Journal of Applied Sciences                      | 0                                                         | 1                                                         |  29                                                       | 2719                                                      | 0.0106660                                                 | \n",
-       "| 6400153145                                                | Cough                                                     | 0                                                         | 1                                                         | 119                                                       |  121                                                      | 0.9834700                                                 | \n",
-       "| 7400153105                                                | Journal of Mathematics and Statistics                     | 0                                                         | 1                                                         |   6                                                       |  616                                                      | 0.0097403                                                 | \n",
-       "| 8300153132                                                | American Journal of Agricultural and Biological Science   | 0                                                         | 1                                                         |  11                                                       |  530                                                      | 0.0207550                                                 | \n",
-       "| 10400153308                                               | American Journal of Immunology                            | 0                                                         | 1                                                         |   0                                                       |  196                                                      | 0.0000000                                                 | \n",
-       "| 11400153336                                               | Estonian Journal of Ecology                               | 0                                                         | 1                                                         | 136                                                       |  152                                                      | 0.8947400                                                 | \n",
-       "| 12100155654                                               | Biomedical Imaging and Intervention Journal               | 0                                                         | 1                                                         |  54                                                       |  256                                                      | 0.2109400                                                 | \n",
-       "| 16200154706                                               | Romanticism on the Net                                    | 0                                                         | 1                                                         |   0                                                       |  511                                                      | 0.0000000                                                 | \n",
-       "| 17200154704                                               | International Journal of Soft Computing                   | 0                                                         | 1                                                         |   0                                                       |  106                                                      | 0.0000000                                                 | \n",
-       "| 17600155016                                               | BMC Medical Physics                                       | 0                                                         | 1                                                         |  26                                                       |   26                                                      | 1.0000000                                                 | \n",
-       "| 17600155057                                               | Living Reviews in Landscape Research                      | 0                                                         | 1                                                         |   5                                                       |   21                                                      | 0.2381000                                                 | \n",
-       "| 17900156726                                               | Formalized Mathematics                                    | 0                                                         | 1                                                         |  91                                                       |  350                                                      | 0.2600000                                                 | \n",
-       "| 19600157021                                               | Macedonian Journal of Medical Sciences                    | 0                                                         | 1                                                         |  54                                                       |  424                                                      | 0.1273600                                                 | \n",
-       "| 19700166520                                               | Cases Journal                                             | 0                                                         | 1                                                         | 625                                                       | 1741                                                      | 0.3589900                                                 | \n",
-       "| 19700174685                                               | Journal of Experimental Stroke and Translational Medicine | 0                                                         | 1                                                         |   0                                                       |   40                                                      | 0.0000000                                                 | \n",
-       "| ⋮ | ⋮ | ⋮ | ⋮ | ⋮ | ⋮ | ⋮ | \n",
-       "| 21100197523                                                             | International Journal of Multimedia and Ubiquitous Engineering          | 0                                                                       | 1                                                                       |   6                                                                     | 1484                                                                    | 0.0040431                                                               | \n",
-       "| 21100198717                                                             | Open Catalysis Journal                                                  | 0                                                                       | 1                                                                       |   0                                                                     |   80                                                                    | 0.0000000                                                               | \n",
-       "| 21100199112                                                             | International Journal of Security and its Applications                  | 0                                                                       | 1                                                                       |   5                                                                     | 1141                                                                    | 0.0043821                                                               | \n",
-       "| 21100199850                                                             | International Journal of Software Engineering and its Applications      | 0                                                                       | 1                                                                       |   2                                                                     |  608                                                                    | 0.0032895                                                               | \n",
-       "| 21100200033                                                             | Frontiers in Neuroenergetics                                            | 0                                                                       | 1                                                                       |   2                                                                     |   71                                                                    | 0.0281690                                                               | \n",
-       "| 21100200204                                                             | Journal of Dental Biomechanics                                          | 0                                                                       | 1                                                                       |  13                                                                     |   37                                                                    | 0.3513500                                                               | \n",
-       "| 21100202936                                                             | Biology and Medicine                                                    | 0                                                                       | 1                                                                       |   1                                                                     |  229                                                                    | 0.0043668                                                               | \n",
-       "| 21100205766                                                             | Perspectives in Medicine                                                | 0                                                                       | 1                                                                       | 123                                                                     |  123                                                                    | 1.0000000                                                               | \n",
-       "| 21100206606                                                             | Investigaciones Europeas de Direccion y Economia de la Empresa          | 0                                                                       | 1                                                                       | 197                                                                     |  197                                                                    | 1.0000000                                                               | \n",
-       "| 21100211347                                                             | Trials in Vaccinology                                                   | 0                                                                       | 1                                                                       |  80                                                                     |   81                                                                    | 0.9876500                                                               | \n",
-       "| 21100220119                                                             | Korean Journal of Pediatric Infectious Diseases                         | 0                                                                       | 1                                                                       |   0                                                                     |   27                                                                    | 0.0000000                                                               | \n",
-       "| 21100220137                                                             | Bioscience Education                                                    | 0                                                                       | 1                                                                       | 216                                                                     |  263                                                                    | 0.8212900                                                               | \n",
-       "| 21100223579                                                             | Advanced Materials Letters                                              | 0                                                                       | 1                                                                       |  52                                                                     |  907                                                                    | 0.0573320                                                               | \n",
-       "| 21100258399                                                             | Optical Nanoscopy                                                       | 0                                                                       | 1                                                                       |  19                                                                     |   20                                                                    | 0.9500000                                                               | \n",
-       "| 21100258967                                                             | ISRN Mechanical Engineering                                             | 0                                                                       | 1                                                                       | 120                                                                     |  137                                                                    | 0.8759100                                                               | \n",
-       "| 21100264566                                                             | South Asian Journal of Cancer                                           | 0                                                                       | 1                                                                       |   4                                                                     |  403                                                                    | 0.0099256                                                               | \n",
-       "| 21100265048                                                             | Contemporary Engineering Sciences                                       | 0                                                                       | 1                                                                       |   9                                                                     |  616                                                                    | 0.0146100                                                               | \n",
-       "| 21100266906                                                             | ISRN Communications and Networking                                      | 0                                                                       | 1                                                                       |   8                                                                     |   67                                                                    | 0.1194000                                                               | \n",
-       "| 21100268208                                                             | Video Journal and Encyclopedia of GI Endoscopy                          | 0                                                                       | 1                                                                       | 297                                                                     |  297                                                                    | 1.0000000                                                               | \n",
-       "| 21100293201                                                             | International Journal of Research in Ayurveda and Pharmacy              | 0                                                                       | 1                                                                       |   2                                                                     |  863                                                                    | 0.0023175                                                               | \n",
-       "| 21100386191                                                             | ISRN Signal Processing                                                  | 0                                                                       | 1                                                                       |   5                                                                     |   84                                                                    | 0.0595240                                                               | \n",
-       "| 21100386192                                                             | ISRN Civil Engineering                                                  | 0                                                                       | 1                                                                       |  60                                                                     |   71                                                                    | 0.8450700                                                               | \n",
-       "| 21100399105                                                             | Journal of Nonlinear Science and Applications                           | 0                                                                       | 1                                                                       |   0                                                                     |  111                                                                    | 0.0000000                                                               | \n",
-       "| 21100422125                                                             | International Journal of Applied Linguistics and English Literature     | 0                                                                       | 1                                                                       |   0                                                                     | 1010                                                                    | 0.0000000                                                               | \n",
-       "| 21100432005                                                             | Journal of Signal Transduction                                          | 0                                                                       | 1                                                                       |  73                                                                     |  112                                                                    | 0.6517900                                                               | \n",
-       "| 21100437958                                                             | American Journal of Engineering and Applied Sciences                    | 0                                                                       | 1                                                                       |   2                                                                     |  658                                                                    | 0.0030395                                                               | \n",
-       "| 21100447121                                                             | International Journal of Future Generation Communication and Networking | 0                                                                       | 1                                                                       |  11                                                                     |  770                                                                    | 0.0142860                                                               | \n",
-       "| 21100456184                                                             | Applied Petrochemical Research                                          | 0                                                                       | 1                                                                       | 172                                                                     |  174                                                                    | 0.9885100                                                               | \n",
-       "| 21100457107                                                             | SAGE Open Medicine                                                      | 0                                                                       | 1                                                                       | 206                                                                     |  287                                                                    | 0.7177700                                                               | \n",
-       "| 21100464757                                                             | ISRN Dermatology                                                        | 0                                                                       | 1                                                                       |  96                                                                     |  100                                                                    | 0.9600000                                                               | \n",
+       "|---|---|\n",
+       "| 18607                            | Primary Care Respiratory Journal | 0                                | 1                                | 469                              | 1259                             | 0.37252                          | \n",
+       "| 18889                            | Indian Journal of Human Genetics | 0                                | 1                                | 347                              |  475                             | 0.73053                          | \n",
        "\n",
        "\n"
       ],
       "text/plain": [
-       "   scopus_id  \n",
-       "1  18607      \n",
-       "2  18889      \n",
-       "3  19523      \n",
-       "4  19555      \n",
-       "5  20353      \n",
-       "6  21991      \n",
-       "7  23684      \n",
-       "8  24557      \n",
-       "9  26700      \n",
-       "10 38536      \n",
-       "11 130093     \n",
-       "12 5100152606 \n",
-       "13 5400152617 \n",
-       "14 5400152637 \n",
-       "15 5800179602 \n",
-       "16 6400153122 \n",
-       "17 6400153145 \n",
-       "18 7400153105 \n",
-       "19 8300153132 \n",
-       "20 10400153308\n",
-       "21 11400153336\n",
-       "22 12100155654\n",
-       "23 16200154706\n",
-       "24 17200154704\n",
-       "25 17600155016\n",
-       "26 17600155057\n",
-       "27 17900156726\n",
-       "28 19600157021\n",
-       "29 19700166520\n",
-       "30 19700174685\n",
-       "⋮  ⋮          \n",
-       "41 21100197523\n",
-       "42 21100198717\n",
-       "43 21100199112\n",
-       "44 21100199850\n",
-       "45 21100200033\n",
-       "46 21100200204\n",
-       "47 21100202936\n",
-       "48 21100205766\n",
-       "49 21100206606\n",
-       "50 21100211347\n",
-       "51 21100220119\n",
-       "52 21100220137\n",
-       "53 21100223579\n",
-       "54 21100258399\n",
-       "55 21100258967\n",
-       "56 21100264566\n",
-       "57 21100265048\n",
-       "58 21100266906\n",
-       "59 21100268208\n",
-       "60 21100293201\n",
-       "61 21100386191\n",
-       "62 21100386192\n",
-       "63 21100399105\n",
-       "64 21100422125\n",
-       "65 21100432005\n",
-       "66 21100437958\n",
-       "67 21100447121\n",
-       "68 21100456184\n",
-       "69 21100457107\n",
-       "70 21100464757\n",
-       "   title_name                                                             \n",
-       "1  Primary Care Respiratory Journal                                       \n",
-       "2  Indian Journal of Human Genetics                                       \n",
-       "3  Bulletin of the Veterinary Institute in Pulawy                         \n",
-       "4  Veterinary Research                                                    \n",
-       "5  South African Journal of Wildlife Research                             \n",
-       "6  New South Wales public health bulletin                                 \n",
-       "7  Informatics in Primary Care                                            \n",
-       "8  Mathematical and Computational Applications                            \n",
-       "9  Revista Argentina de Endocrinologia y Metabolismo                      \n",
-       "10 Turk Serebrovaskuler Hastaliklar Dergisi                               \n",
-       "11 Biogeosciences Discussions                                             \n",
-       "12 Biosciences Biotechnology Research Asia                                \n",
-       "13 American Journal of Environmental Sciences                             \n",
-       "14 American Journal of Infectious Diseases                                \n",
-       "15 Scoliosis                                                              \n",
-       "16 American Journal of Applied Sciences                                   \n",
-       "17 Cough                                                                  \n",
-       "18 Journal of Mathematics and Statistics                                  \n",
-       "19 American Journal of Agricultural and Biological Science                \n",
-       "20 American Journal of Immunology                                         \n",
-       "21 Estonian Journal of Ecology                                            \n",
-       "22 Biomedical Imaging and Intervention Journal                            \n",
-       "23 Romanticism on the Net                                                 \n",
-       "24 International Journal of Soft Computing                                \n",
-       "25 BMC Medical Physics                                                    \n",
-       "26 Living Reviews in Landscape Research                                   \n",
-       "27 Formalized Mathematics                                                 \n",
-       "28 Macedonian Journal of Medical Sciences                                 \n",
-       "29 Cases Journal                                                          \n",
-       "30 Journal of Experimental Stroke and Translational Medicine              \n",
-       "⋮  ⋮                                                                      \n",
-       "41 International Journal of Multimedia and Ubiquitous Engineering         \n",
-       "42 Open Catalysis Journal                                                 \n",
-       "43 International Journal of Security and its Applications                 \n",
-       "44 International Journal of Software Engineering and its Applications     \n",
-       "45 Frontiers in Neuroenergetics                                           \n",
-       "46 Journal of Dental Biomechanics                                         \n",
-       "47 Biology and Medicine                                                   \n",
-       "48 Perspectives in Medicine                                               \n",
-       "49 Investigaciones Europeas de Direccion y Economia de la Empresa         \n",
-       "50 Trials in Vaccinology                                                  \n",
-       "51 Korean Journal of Pediatric Infectious Diseases                        \n",
-       "52 Bioscience Education                                                   \n",
-       "53 Advanced Materials Letters                                             \n",
-       "54 Optical Nanoscopy                                                      \n",
-       "55 ISRN Mechanical Engineering                                            \n",
-       "56 South Asian Journal of Cancer                                          \n",
-       "57 Contemporary Engineering Sciences                                      \n",
-       "58 ISRN Communications and Networking                                     \n",
-       "59 Video Journal and Encyclopedia of GI Endoscopy                         \n",
-       "60 International Journal of Research in Ayurveda and Pharmacy             \n",
-       "61 ISRN Signal Processing                                                 \n",
-       "62 ISRN Civil Engineering                                                 \n",
-       "63 Journal of Nonlinear Science and Applications                          \n",
-       "64 International Journal of Applied Linguistics and English Literature    \n",
-       "65 Journal of Signal Transduction                                         \n",
-       "66 American Journal of Engineering and Applied Sciences                   \n",
-       "67 International Journal of Future Generation Communication and Networking\n",
-       "68 Applied Petrochemical Research                                         \n",
-       "69 SAGE Open Medicine                                                     \n",
-       "70 ISRN Dermatology                                                       \n",
-       "   active open_access scihub crossref coverage \n",
-       "1  0      1           469    1259     0.3725200\n",
-       "2  0      1           347     475     0.7305300\n",
-       "3  0      1           117     232     0.5043100\n",
-       "4  0      1           757    1507     0.5023200\n",
-       "5  0      1           196     198     0.9899000\n",
-       "6  0      1            36    1815     0.0198350\n",
-       "7  0      1             0      27     0.0000000\n",
-       "8  0      1             0     843     0.0000000\n",
-       "9  0      1            30      34     0.8823500\n",
-       "10 0      1             0     106     0.0000000\n",
-       "11 0      1            46    3989     0.0115320\n",
-       "12 0      1             8    1646     0.0048603\n",
-       "13 0      1             2     756     0.0026455\n",
-       "14 0      1             1     344     0.0029070\n",
-       "15 0      1           769     970     0.7927800\n",
-       "16 0      1            29    2719     0.0106660\n",
-       "17 0      1           119     121     0.9834700\n",
-       "18 0      1             6     616     0.0097403\n",
-       "19 0      1            11     530     0.0207550\n",
-       "20 0      1             0     196     0.0000000\n",
-       "21 0      1           136     152     0.8947400\n",
-       "22 0      1            54     256     0.2109400\n",
-       "23 0      1             0     511     0.0000000\n",
-       "24 0      1             0     106     0.0000000\n",
-       "25 0      1            26      26     1.0000000\n",
-       "26 0      1             5      21     0.2381000\n",
-       "27 0      1            91     350     0.2600000\n",
-       "28 0      1            54     424     0.1273600\n",
-       "29 0      1           625    1741     0.3589900\n",
-       "30 0      1             0      40     0.0000000\n",
-       "⋮  ⋮      ⋮           ⋮      ⋮        ⋮        \n",
-       "41 0      1             6    1484     0.0040431\n",
-       "42 0      1             0      80     0.0000000\n",
-       "43 0      1             5    1141     0.0043821\n",
-       "44 0      1             2     608     0.0032895\n",
-       "45 0      1             2      71     0.0281690\n",
-       "46 0      1            13      37     0.3513500\n",
-       "47 0      1             1     229     0.0043668\n",
-       "48 0      1           123     123     1.0000000\n",
-       "49 0      1           197     197     1.0000000\n",
-       "50 0      1            80      81     0.9876500\n",
-       "51 0      1             0      27     0.0000000\n",
-       "52 0      1           216     263     0.8212900\n",
-       "53 0      1            52     907     0.0573320\n",
-       "54 0      1            19      20     0.9500000\n",
-       "55 0      1           120     137     0.8759100\n",
-       "56 0      1             4     403     0.0099256\n",
-       "57 0      1             9     616     0.0146100\n",
-       "58 0      1             8      67     0.1194000\n",
-       "59 0      1           297     297     1.0000000\n",
-       "60 0      1             2     863     0.0023175\n",
-       "61 0      1             5      84     0.0595240\n",
-       "62 0      1            60      71     0.8450700\n",
-       "63 0      1             0     111     0.0000000\n",
-       "64 0      1             0    1010     0.0000000\n",
-       "65 0      1            73     112     0.6517900\n",
-       "66 0      1             2     658     0.0030395\n",
-       "67 0      1            11     770     0.0142860\n",
-       "68 0      1           172     174     0.9885100\n",
-       "69 0      1           206     287     0.7177700\n",
-       "70 0      1            96     100     0.9600000"
+       "  scopus_id title_name                       active open_access scihub crossref\n",
+       "1 18607     Primary Care Respiratory Journal 0      1           469    1259    \n",
+       "2 18889     Indian Journal of Human Genetics 0      1           347     475    \n",
+       "  coverage\n",
+       "1 0.37252 \n",
+       "2 0.73053 "
       ]
      },
      "metadata": {},
@@ -583,7 +226,8 @@
    "source": [
     "journal_df %>%\n",
     "  dplyr::filter(active == 0) %>%\n",
-    "  dplyr::filter(open_access == 1)"
+    "  dplyr::filter(open_access == 1) %>%\n",
+    "  head(2)"
    ]
   },
   {
@@ -966,12 +610,55 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<dl>\n",
+       "\t<dt>$crossref_url</dt>\n",
+       "\t\t<dd>'https://github.com/greenelab/crossref/raw/768a49ba1d8ba1971f00471950514716a9f699c8/'</dd>\n",
+       "\t<dt>$scopus_url</dt>\n",
+       "\t\t<dd>'https://github.com/dhimmel/scopus/raw/50171219c2b2261bd2529f8ca354e4ba25725626/'</dd>\n",
+       "\t<dt>$opencitations_url</dt>\n",
+       "\t\t<dd>'https://github.com/greenelab/opencitations/raw/b69e814318dfd58e5f711f5373d4ff8683ac0ba2/'</dd>\n",
+       "</dl>\n"
+      ],
+      "text/latex": [
+       "\\begin{description}\n",
+       "\\item[\\$crossref\\_url] 'https://github.com/greenelab/crossref/raw/768a49ba1d8ba1971f00471950514716a9f699c8/'\n",
+       "\\item[\\$scopus\\_url] 'https://github.com/dhimmel/scopus/raw/50171219c2b2261bd2529f8ca354e4ba25725626/'\n",
+       "\\item[\\$opencitations\\_url] 'https://github.com/greenelab/opencitations/raw/b69e814318dfd58e5f711f5373d4ff8683ac0ba2/'\n",
+       "\\end{description}\n"
+      ],
+      "text/markdown": [
+       "$crossref_url\n",
+       ":   'https://github.com/greenelab/crossref/raw/768a49ba1d8ba1971f00471950514716a9f699c8/'\n",
+       "$scopus_url\n",
+       ":   'https://github.com/dhimmel/scopus/raw/50171219c2b2261bd2529f8ca354e4ba25725626/'\n",
+       "$opencitations_url\n",
+       ":   'https://github.com/greenelab/opencitations/raw/b69e814318dfd58e5f711f5373d4ff8683ac0ba2/'\n",
+       "\n",
+       "\n"
+      ],
+      "text/plain": [
+       "$crossref_url\n",
+       "[1] \"https://github.com/greenelab/crossref/raw/768a49ba1d8ba1971f00471950514716a9f699c8/\"\n",
+       "\n",
+       "$scopus_url\n",
+       "[1] \"https://github.com/dhimmel/scopus/raw/50171219c2b2261bd2529f8ca354e4ba25725626/\"\n",
+       "\n",
+       "$opencitations_url\n",
+       "[1] \"https://github.com/greenelab/opencitations/raw/b69e814318dfd58e5f711f5373d4ff8683ac0ba2/\"\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
-    "config = '00.configuration.json' %>% jsonlite::read_json()"
+    "config = '00.configuration.json' %>% jsonlite::read_json()\n",
+    "config"
    ]
   },
   {
@@ -1268,12 +955,157 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Journal / Publisher coverage distributions"
+    "### Publisher Coverage dataframe"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 16,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Parsed with column specification:\n",
+      "cols(\n",
+      "  main_publisher_slug = col_character(),\n",
+      "  main_publisher = col_character(),\n",
+      "  n_journals = col_integer(),\n",
+      "  name_variants = col_integer()\n",
+      ")\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<table>\n",
+       "<thead><tr><th scope=col>main_publisher_slug</th><th scope=col>main_publisher</th></tr></thead>\n",
+       "<tbody>\n",
+       "\t<tr><td>1105-media-inc </td><td>1105 Media Inc.</td></tr>\n",
+       "\t<tr><td>3g-publishing  </td><td>3G Publishing  </td></tr>\n",
+       "</tbody>\n",
+       "</table>\n"
+      ],
+      "text/latex": [
+       "\\begin{tabular}{r|ll}\n",
+       " main\\_publisher\\_slug & main\\_publisher\\\\\n",
+       "\\hline\n",
+       "\t 1105-media-inc  & 1105 Media Inc.\\\\\n",
+       "\t 3g-publishing   & 3G Publishing  \\\\\n",
+       "\\end{tabular}\n"
+      ],
+      "text/markdown": [
+       "\n",
+       "main_publisher_slug | main_publisher | \n",
+       "|---|---|\n",
+       "| 1105-media-inc  | 1105 Media Inc. | \n",
+       "| 3g-publishing   | 3G Publishing   | \n",
+       "\n",
+       "\n"
+      ],
+      "text/plain": [
+       "  main_publisher_slug main_publisher \n",
+       "1 1105-media-inc      1105 Media Inc.\n",
+       "2 3g-publishing       3G Publishing  "
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# Read publisher slugs\n",
+    "slug_df = paste0(config$scopus_url, 'data/publishers.tsv') %>%\n",
+    "  readr::read_tsv() %>%\n",
+    "  dplyr::select(main_publisher_slug, main_publisher)\n",
+    "slug_df %>% head(2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Joining, by = \"main_publisher\"\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<table>\n",
+       "<thead><tr><th scope=col>main_publisher</th><th scope=col>journals</th><th scope=col>scihub</th><th scope=col>crossref_open_access</th><th scope=col>crossref_active</th><th scope=col>crossref</th><th scope=col>coverage</th><th scope=col>main_publisher_slug</th></tr></thead>\n",
+       "<tbody>\n",
+       "\t<tr><td>A and V Publication    </td><td>1                      </td><td>  0                    </td><td>0                      </td><td>765                    </td><td>765                    </td><td>0                      </td><td>a-and-v-publication    </td></tr>\n",
+       "\t<tr><td>A B Academic Publishers</td><td>1                      </td><td>318                    </td><td>0                      </td><td>  0                    </td><td>318                    </td><td>1                      </td><td>a-b-academic-publishers</td></tr>\n",
+       "</tbody>\n",
+       "</table>\n"
+      ],
+      "text/latex": [
+       "\\begin{tabular}{r|llllllll}\n",
+       " main\\_publisher & journals & scihub & crossref\\_open\\_access & crossref\\_active & crossref & coverage & main\\_publisher\\_slug\\\\\n",
+       "\\hline\n",
+       "\t A and V Publication     & 1                       &   0                     & 0                       & 765                     & 765                     & 0                       & a-and-v-publication    \\\\\n",
+       "\t A B Academic Publishers & 1                       & 318                     & 0                       &   0                     & 318                     & 1                       & a-b-academic-publishers\\\\\n",
+       "\\end{tabular}\n"
+      ],
+      "text/markdown": [
+       "\n",
+       "main_publisher | journals | scihub | crossref_open_access | crossref_active | crossref | coverage | main_publisher_slug | \n",
+       "|---|---|\n",
+       "| A and V Publication     | 1                       |   0                     | 0                       | 765                     | 765                     | 0                       | a-and-v-publication     | \n",
+       "| A B Academic Publishers | 1                       | 318                     | 0                       |   0                     | 318                     | 1                       | a-b-academic-publishers | \n",
+       "\n",
+       "\n"
+      ],
+      "text/plain": [
+       "  main_publisher          journals scihub crossref_open_access crossref_active\n",
+       "1 A and V Publication     1          0    0                    765            \n",
+       "2 A B Academic Publishers 1        318    0                      0            \n",
+       "  crossref coverage main_publisher_slug    \n",
+       "1 765      0        a-and-v-publication    \n",
+       "2 318      1        a-b-academic-publishers"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "publisher_df = coverage_df %>%\n",
+    "  dplyr::filter(facet == \"Publisher\") %>%\n",
+    "  dplyr::select(-facet) %>%\n",
+    "  dplyr::rename(main_publisher = category) %>%\n",
+    "  dplyr::inner_join(slug_df)\n",
+    "publisher_df %>% head(2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "publisher_df %>%\n",
+    "  readr::write_tsv(file.path('data', 'publisher-coverage.tsv'))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Journal / Publisher coverage distributions"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
    "metadata": {
     "collapsed": true
    },
@@ -1310,7 +1142,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 20,
    "metadata": {
     "collapsed": true
    },
@@ -1333,7 +1165,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 21,
    "metadata": {
     "collapsed": true
    },
@@ -1398,7 +1230,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 22,
    "metadata": {
     "collapsed": true,
     "scrolled": false
@@ -1427,7 +1259,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 23,
    "metadata": {
     "collapsed": true
    },
@@ -1456,7 +1288,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 24,
    "metadata": {
     "collapsed": true,
     "scrolled": false
@@ -1493,7 +1325,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 25,
    "metadata": {},
    "outputs": [
     {
@@ -1559,7 +1391,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 26,
    "metadata": {
     "collapsed": true
    },
@@ -1586,7 +1418,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 27,
    "metadata": {},
    "outputs": [
     {
@@ -1649,7 +1481,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 28,
    "metadata": {},
    "outputs": [
     {
@@ -1678,7 +1510,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 29,
    "metadata": {
     "collapsed": true
    },
@@ -1712,7 +1544,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 30,
    "metadata": {},
    "outputs": [
     {
@@ -1777,7 +1609,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 31,
    "metadata": {
     "collapsed": true
    },

--- a/data/publisher-coverage.tsv
+++ b/data/publisher-coverage.tsv
@@ -1,0 +1,3833 @@
+main_publisher	journals	scihub	crossref_open_access	crossref_active	crossref	coverage	main_publisher_slug
+A and V Publication	1	0	0	765	765	0.0	a-and-v-publication
+A B Academic Publishers	1	318	0	0	318	1.0	a-b-academic-publishers
+A Escola	1	0	0	522	522	0.0	a-escola
+A. Colin	5	46	0	14742	14742	0.003120336453669787	a-colin
+A. Hidalgo	1	0	0	212	212	0.0	a-hidalgo
+A. Maisonneuve	1	1	0	0	565	0.0017699115044247787	a-maisonneuve
+A.A. Balkema	1	650	0	0	657	0.989345509893455	a-a-balkema
+A.D.A.C.	3	763	0	865	865	0.8820809248554913	a-d-a-c
+A.K. Sharma, Ed. & Pub.	1	0	0	10	10	0.0	a-k-sharma-ed-pub
+AAGR Aerosol and Air Quality Research	1	34	0	1307	1307	0.026013771996939557	aagr-aerosol-and-air-quality-research
+AAPM - American Association of Physicists in Medicine	1	58	146	146	146	0.3972602739726027	aapm-american-association-of-physicists-in-medicine
+Ab Imperio	1	77	0	2198	2198	0.03503184713375796	ab-imperio
+ABCD (Diabetes Care) Ltd	1	800	0	903	903	0.8859357696566998	abcd-diabetes-care-ltd
+Ablex Pub. Corp	2	495	0	0	1744	0.2838302752293578	ablex-pub-corp
+ABPol	1	13	1008	1008	1008	0.012896825396825396	abpol
+ABV-press Publishing house, LLC	1	0	90	90	90	0.0	abv-press-publishing-house-llc
+Academia Brasileira de Ciencias	1	24	1820	1820	1820	0.013186813186813187	academia-brasileira-de-ciencias
+Academia de Ciencias Medicas de Bilbao	1	453	0	453	453	1.0	academia-de-ciencias-medicas-de-bilbao
+Academia Romana	1	13	0	225	225	0.057777777777777775	academia-romana
+Academia Sinica	2	530	1289	1885	1885	0.28116710875331563	academia-sinica
+Academic Educational Forum on International Relations	1	0	0	96	96	0.0	academic-educational-forum-on-international-relations
+Academic Journals	34	383	0	0	23195	0.016512179348997628	academic-journals
+Academic Mexicana de Cirugia	1	312	0	317	317	0.9842271293375394	academic-mexicana-de-cirugia
+Academic Mind	1	0	0	67	67	0.0	academic-mind
+Academic Press	1	0	314	314	314	0.0	academic-press
+Academic Publications Ltd	1	3	1794	1794	1794	0.0016722408026755853	academic-publications-ltd
+Academic Publishing House Researcher	1	0	158	158	158	0.0	academic-publishing-house-researcher
+Academie Serbe des Sciences	1	0	0	0	42	0.0	academie-serbe-des-sciences
+Academie Veterinaire de France	1	0	0	770	770	0.0	academie-veterinaire-de-france
+Academy of Environmental Biology	2	0	50	50	75	0.0	academy-of-environmental-biology
+Academy of Managed Care Pharmacy	1	0	0	0	1539	0.0	academy-of-managed-care-pharmacy
+Academy of Managed Care Pharmacy (AMCP)	1	0	0	338	338	0.0	academy-of-managed-care-pharmacy-amcp
+Academy of Management	4	6607	0	10107	10597	0.6234783429272436	academy-of-management
+Academy of Natural Sciences of Philadelphia	1	186	0	188	188	0.9893617021276596	academy-of-natural-sciences-of-philadelphia
+Academy of Physical Education	1	597	781	781	781	0.764404609475032	academy-of-physical-education
+Academy of Sciences and Arts of Bosnia and Herzegovina	1	102	153	153	153	0.6666666666666666	academy-of-sciences-and-arts-of-bosnia-and-herzegovina
+Academy of Sciences of the Czech Republic	3	36	223	268	268	0.13432835820895522	academy-of-sciences-of-the-czech-republic
+Academy of Scientific Research and Technology	1	184	192	192	192	0.9583333333333334	academy-of-scientific-research-and-technology
+Academy of Taiwan Information Systems Research	1	0	92	92	92	0.0	academy-of-taiwan-information-systems-research
+Academy Publisher	7	64	0	0	10588	0.006044578768417076	academy-publisher
+Academy Science Publishers	1	0	0	0	375	0.0	academy-science-publishers
+Accademia Nazionale dei Lincei	1	514	0	514	514	1.0	accademia-nazionale-dei-lincei
+ACCB Publishing	1	0	0	104	104	0.0	accb-publishing
+Accreditation Council for Graduate Medical Education	1	22	0	1356	1356	0.016224188790560472	accreditation-council-for-graduate-medical-education
+Acoustical Society of America	2	56174	0	146304	146452	0.38356594652172726	acoustical-society-of-america
+Acoustical Society of Japan	1	2	1071	1071	1071	0.0018674136321195146	acoustical-society-of-japan
+ACT Publishing Group Limited	1	0	0	0	170	0.0	act-publishing-group-limited
+Acta Endocrinologica Foundation	1	324	812	812	812	0.39901477832512317	acta-endocrinologica-foundation
+ACTA Press	2	0	0	5	5	0.0	acta-press
+Acta Radiologica	1	31	0	0	117	0.26495726495726496	acta-radiologica
+Actes Sud, Universite d'Avignon	1	0	0	170	170	0.0	actes-sud-universite-davignon
+Ad Libros Publications Ltd.	1	56	0	0	56	1.0	ad-libros-publications-ltd
+Adam Mickiewicz University Press	4	125	647	1045	1045	0.11961722488038277	adam-mickiewicz-university-press
+Adolph Holzhausens Nachfolger	1	0	0	661	661	0.0	adolph-holzhausens-nachfolger
+Advance Electromagnetics	1	0	156	156	156	0.0	advance-electromagnetics
+Advanced Institute of Convergence Information Technology Research Center	6	34	0	0	13378	0.00254148602182688	advanced-institute-of-convergence-information-technology-research-center
+Advanced Research Journals	3	3	0	0	138	0.021739130434782608	advanced-research-journals
+AEDEI, the Spanish Association for Irish Studies	1	0	88	88	88	0.0	aedei-the-spanish-association-for-irish-studies
+Aeolus Press	1	421	0	0	421	1.0	aeolus-press
+AEP - Academic Electronic Press Ltd.	1	0	0	10	10	0.0	aep-academic-electronic-press-ltd
+Aerospace Medical Association	2	1616	0	382	1772	0.9119638826185101	aerospace-medical-association
+AFEMOTI	1	0	0	0	183	0.0	afemoti
+Africa Institute of South Afrcia	1	0	0	0	443	0.0	africa-institute-of-south-afrcia
+Africa Magna Verlag	1	5	0	290	290	0.017241379310344827	africa-magna-verlag
+Africagrowth Institute	1	84	85	85	85	0.9882352941176471	africagrowth-institute
+African Center for Research and Information on Substance Abuse	1	0	0	32	32	0.0	african-center-for-research-and-information-on-substance-abuse
+African Ethnomedicines Network	1	0	0	118	118	0.0	african-ethnomedicines-network
+African Federation for Emergency Medicine	1	377	390	390	390	0.9666666666666667	african-federation-for-emergency-medicine
+African Forum for Health Sciences	1	1318	0	0	1319	0.9992418498862775	african-forum-for-health-sciences
+African Journal of Clinical and Experimental Microbiology	1	0	0	416	416	0.0	african-journal-of-clinical-and-experimental-microbiology
+African Journal of Health Sciences	1	0	0	0	125	0.0	african-journal-of-health-sciences
+African Journals online	2	0	622	622	622	0.0	african-journals-online
+African Networks on Ethnomedicines	1	11	0	0	1197	0.0091896407685881365	african-networks-on-ethnomedicines
+African Scholarly Science Communications Trust (ASSCAT)	1	2	0	434	434	0.004608294930875576	african-scholarly-science-communications-trust-asscat
+African Studies Center of Boston University	2	1085	0	757	1085	1.0	african-studies-center-of-boston-university
+Africana Pub. Co.	1	5482	0	5482	5482	1.0	africana-pub-co
+Agencja Wydawnicza ARIES	1	2990	0	3024	3024	0.9887566137566137	agencja-wydawnicza-aries
+Agora University	1	0	0	722	722	0.0	agora-university
+Agricultural Extension Society of Nigeria	1	0	0	266	266	0.0	agricultural-extension-society-of-nigeria
+Agricultural History Society	1	367	0	891	891	0.4118967452300786	agricultural-history-society
+Agricultural Institute of Canada	3	3826	0	12990	12990	0.2945342571208622	agricultural-institute-of-canada
+Agricultural Research Communication Centre	3	412	0	1586	1586	0.2597730138713745	agricultural-research-communication-centre
+Agricultural University of Iceland	1	0	5	5	5	0.0	agricultural-university-of-iceland
+Agroinform	1	0	0	0	117	0.0	agroinform
+Ahmet Yesevi Universitesi	1	0	0	78	78	0.0	ahmet-yesevi-universitesi
+AIMS Press	1	0	0	97	97	0.0	aims-press
+Ain Shams University	3	1360	1192	1391	1391	0.9777138749101366	ain-shams-university
+Air Pollution Control Association	2	4172	0	0	4176	0.9990421455938697	air-pollution-control-association
+Akademi Doktorlar Yayinevi	1	144	0	196	196	0.7346938775510204	akademi-doktorlar-yayinevi
+Akademia Gorniczo-Hutnicza im. S. Staszica w Krakowie.	1	11	396	396	396	0.027777777777777776	akademia-gorniczo-hutnicza-im-s-staszica-w-krakowie
+Akademia Medyczna we Wroclawiu/Wroclaw Medical University	2	1	0	458	458	0.002183406113537118	akademia-medyczna-we-wroclawiu-wroclaw-medical-university
+Akademia teologii katolickiej	1	0	0	0	32	0.0	akademia-teologii-katolickiej
+Akademia Wychowania Fizycznego we Wroclawiu	1	112	0	198	198	0.5656565656565656	akademia-wychowania-fizycznego-we-wroclawiu
+Akademiai Kiado	59	19569	258	20764	37422	0.5229276895943563	akademiai-kiado
+Akademie Ved Ceske Republiky	8	6445	2695	4890	24079	0.26766061713526307	akademie-ved-ceske-republiky
+Akademie Verlag	3	5952	0	0	9541	0.6238339796667016	akademie-verlag
+Akademiia Nauk Sssr	1	0	0	0	325	0.0	akademiia-nauk-sssr
+Akademika Forlag	2	0	145	160	160	0.0	akademika-forlag
+Alan Guttmacher Institute	3	3887	0	207	4100	0.9480487804878048	alan-guttmacher-institute
+Albert Einstein Institut	1	48	140	140	140	0.34285714285714286	albert-einstein-institut
+Alcohol Research Documentation, Inc.	1	7	0	0	43	0.16279069767441862	alcohol-research-documentation-inc
+Alexandria University	1	875	903	903	903	0.9689922480620154	alexandria-university
+Alexandrine Press	1	512	0	562	562	0.9110320284697508	alexandrine-press
+Alexandru Ioan Cuza - University of Iasi	1	5	0	39	39	0.1282051282051282	alexandru-ioan-cuza-university-of-iasi
+Alfred University	1	171	0	218	218	0.7844036697247706	alfred-university
+All India Institute of Medical Sciences	2	0	0	442	442	0.0	all-india-institute-of-medical-sciences
+All-Russian Public Organization Antihypertensive League	1	0	0	127	127	0.0	all-russian-public-organization-antihypertensive-league
+Allen Press	6	4204	0	2144	4681	0.8980986968596454	allen-press
+Allen Press Inc.	3	18777	1898	19184	19184	0.9787844036697247	allen-press-inc
+Alliance Communications Group	2	291	0	0	623	0.46709470304975925	alliance-communications-group
+Almgvist & Wiksells	1	19899	0	0	19899	1.0	almgvist-wiksells
+AlphaMed Press Inc	2	3861	0	3248	3913	0.9867109634551495	alphamed-press-inc
+Altai State University	1	0	154	154	154	0.0	altai-state-university
+AME Publishing Company	15	1532	2405	5484	5484	0.27935813274981763	ame-publishing-company
+American Academy of Audiology	1	973	0	1066	1066	0.9127579737335835	american-academy-of-audiology
+American Academy of Clinical Neurophysiology	1	10	0	0	10	1.0	american-academy-of-clinical-neurophysiology
+American Academy of Insurance Medicine	1	0	0	0	46	0.0	american-academy-of-insurance-medicine
+American Academy of Nurse Practitioners	1	2066	0	0	2095	0.9861575178997614	american-academy-of-nurse-practitioners
+American Academy of Pediatrics	4	19764	0	25356	25356	0.779460482725982	american-academy-of-pediatrics
+American Academy of Periodontology	2	10064	0	9893	10116	0.9948596283115856	american-academy-of-periodontology
+American Accounting Association	13	2181	0	5994	5994	0.3638638638638639	american-accounting-association
+American Alliance For Health, Physical Education, Recreation, And Dance Etc	1	629	0	0	630	0.9984126984126984	american-alliance-for-health-physical-education-recreation-and-dance-etc
+American Animal Hospital Association	1	1201	0	1698	1698	0.7073027090694936	american-animal-hospital-association
+American Anthropological Association	3	1410	898	898	1734	0.8131487889273357	american-anthropological-association
+American Arachnological Society	1	1025	0	1049	1049	0.9771210676835081	american-arachnological-society
+American Association for Cancer Research	6	37262	0	102018	102018	0.3652492697367131	american-association-for-cancer-research
+American Association for Cancer Research Inc.	2	2613	0	4765	4765	0.5483735571878279	american-association-for-cancer-research-inc
+American Association for Clinical Chemistry, Inc.	1	5862	0	5987	5987	0.9791214297644897	american-association-for-clinical-chemistry-inc
+American Association for Respiratory Care	1	1592	0	1788	1788	0.8903803131991052	american-association-for-respiratory-care
+American Association for the Advancement of Science	6	235865	885	267192	268994	0.8768411191327687	american-association-for-the-advancement-of-science
+American Association of Avian Pathologists Inc.	1	7262	0	7280	7280	0.9975274725274725	american-association-of-avian-pathologists-inc
+American Association of Cereal Chemists, Inc.	2	2261	0	3234	3234	0.6991341991341992	american-association-of-cereal-chemists-inc
+American Association of Clinical Endocrinology	1	301	0	2928	2928	0.10280054644808743	american-association-of-clinical-endocrinology
+American Association of Colleges of Pharmacy	1	2486	2519	2519	2519	0.9868995633187773	american-association-of-colleges-of-pharmacy
+American Association of Critical Care Nurses	2	1423	0	1451	1451	0.9807029634734665	american-association-of-critical-care-nurses
+American Association of Gynecologic Laparoscopists	1	3453	0	0	3453	1.0	american-association-of-gynecologic-laparoscopists
+American Association of Immunologists	1	28457	0	28505	28505	0.9983160848973864	american-association-of-immunologists
+American Association of Industrial Nurses	1	1	0	0	726	0.0013774104683195593	american-association-of-industrial-nurses
+American Association of Neurological Surgeons	4	30384	3439	31031	31031	0.9791498823756888	american-association-of-neurological-surgeons
+American Association of Petroleum Geologists	2	1268	0	46218	46218	0.027435198407546844	american-association-of-petroleum-geologists
+American Association of Pharmaceutical Scientists	2	2662	2571	2571	2760	0.9644927536231884	american-association-of-pharmaceutical-scientists
+American Association of Physics Teachers	1	24515	0	24593	24593	0.996828365795145	american-association-of-physics-teachers
+American Association of Teachers of Slavic and East European Languages	1	6565	0	6565	6565	1.0	american-association-of-teachers-of-slavic-and-east-european-languages
+American Association of Textile Chemists and Colorists	2	85	0	138	138	0.6159420289855072	american-association-of-textile-chemists-and-colorists
+American Association of University Professors	1	1849	0	1849	1849	1.0	american-association-of-university-professors
+American Association of Zoo Veterinarians	1	2229	0	2241	2241	0.9946452476572959	american-association-of-zoo-veterinarians
+American Association on Intellectual and Developmental Disabilities	2	963	0	989	989	0.9737108190091001	american-association-on-intellectual-and-developmental-disabilities
+American Association On Mental Deficiency	1	523	0	0	760	0.6881578947368421	american-association-on-mental-deficiency
+American Association on Mental Retardation	1	434	0	0	655	0.6625954198473283	american-association-on-mental-retardation
+American Board of Family Medicine.	1	2127	2214	2214	2214	0.9607046070460704	american-board-of-family-medicine
+American Bryological & Lichenological Society	1	6588	0	10446	10446	0.6306720275703619	american-bryological-lichenological-society
+American Chemical Society	62	1388282	0	1307383	1405388	0.9878282723347573	american-chemical-society
+American College of Allergy, Asthma, & Immunology	1	6375	0	6401	6401	0.9959381346664584	american-college-of-allergy-asthma-immunology
+American College of Chest Physicians	1	4023	0	0	6748	0.5961766449318316	american-college-of-chest-physicians
+American College of Emergency Physicians	1	1968	0	0	1968	1.0	american-college-of-emergency-physicians
+American College of Gastroenterology	1	2	0	429	429	0.004662004662004662	american-college-of-gastroenterology
+American College Of Nurse-Midwives	2	477	0	0	477	1.0	american-college-of-nurse-midwives
+American College of Obstetricians and Gynecologists	2	592	0	0	592	1.0	american-college-of-obstetricians-and-gynecologists
+American College of Physicians	1	7582	0	55117	55117	0.13756191374711976	american-college-of-physicians
+American Concrete Institute	3	59	0	4591	8717	0.006768383618217276	american-concrete-institute
+American Conference of Governmental Industrial Hygienists	1	10	0	0	704	0.014204545454545454	american-conference-of-governmental-industrial-hygienists
+American Congress on Surveying and Mapping	1	11	0	0	11	1.0	american-congress-on-surveying-and-mapping
+American Counseling Association	1	275	0	0	275	1.0	american-counseling-association
+American Dental Association	1	1160	0	0	1160	1.0	american-dental-association
+American Dental Education Association	1	0	0	14	14	0.0	american-dental-education-association
+American Diabetes Association	4	36817	0	41779	41779	0.8812321979942076	american-diabetes-association
+American Economic Association	8	6945	38	8670	8670	0.801038062283737	american-economic-association
+American Entomological Society	2	932	0	943	943	0.9883351007423118	american-entomological-society
+American Epilepsy Society	1	683	1239	1239	1239	0.5512510088781275	american-epilepsy-society
+American Fern Society, Inc.	1	3264	0	3270	3270	0.998165137614679	american-fern-society-inc
+American Fisheries Society	1	3329	0	0	4263	0.7809054656345297	american-fisheries-society
+American Folklore Society	1	8134	0	8838	8838	0.9203439692238063	american-folklore-society
+American Foundry Society	1	342	0	361	361	0.9473684210526315	american-foundry-society
+American Geophysical Union	2	21453	0	26391	26391	0.8128907582130271	american-geophysical-union
+American Helicopter Society	1	136	0	146	146	0.9315068493150684	american-helicopter-society
+American Industrial Hygiene Association	3	584	0	0	8284	0.07049734427812651	american-industrial-hygiene-association
+American Institute of Aeronautics and Astronautics	8	57125	0	59413	59723	0.9564991711735847	american-institute-of-aeronautics-and-astronautics
+American Institute of Chemical Engineers	1	698	0	0	698	1.0	american-institute-of-chemical-engineers
+American Institute of Industrial Engineers	1	712	0	0	712	1.0	american-institute-of-industrial-engineers
+American Institute of Mathematical Sciences	14	1316	0	10974	10974	0.11991981046108985	american-institute-of-mathematical-sciences
+American Institute of Physics	29	533464	7061	556675	594776	0.8969158136844796	american-institute-of-physics
+American Institute of Physics Publishing LLC	1	9	0	0	318	0.02830188679245283	american-institute-of-physics-publishing-llc
+American Intra-Ocular Implant Society	1	1122	0	0	1122	1.0	american-intra-ocular-implant-society
+American Journal of Science	1	8932	0	11547	11547	0.7735342513206893	american-journal-of-science
+American Library Association	3	37	556	2794	2794	0.013242662848962061	american-library-association
+American Malacological Society, Inc.	1	297	0	301	301	0.9867109634551495	american-malacological-society-inc
+American Marketing Association	4	12112	0	12224	12224	0.9908376963350786	american-marketing-association
+American Mathematical Society	15	65560	2884	99329	99523	0.6587422002954091	american-mathematical-society
+American Medical Association	39	394362	0	265131	502482	0.7848281132458476	american-medical-association
+American Meteorological Society	14	56202	0	83655	90771	0.6191625078494233	american-meteorological-society
+American Microscopical Society	1	4465	0	0	4465	1.0	american-microscopical-society
+American Mosquito Control Association	1	1019	0	1022	1022	0.99706457925636	american-mosquito-control-association
+American Museum of Natural History	3	758	239	846	846	0.8959810874704491	american-museum-of-natural-history
+American Music Therapy Association	1	1465	0	1477	1477	0.991875423155044	american-music-therapy-association
+American Nuclear Society	3	7	0	3012	3012	0.0023240371845949536	american-nuclear-society
+American Occupational Therapy Association	2	34	0	7089	7089	0.004796163069544364	american-occupational-therapy-association
+American Optometric Association	1	2313	0	0	2315	0.9991360691144708	american-optometric-association
+American Oriental Society	1	14748	0	14880	14880	0.9911290322580645	american-oriental-society
+American Ornithologists' Union	2	23717	0	23298	23785	0.9971410552869455	american-ornithologists-union
+American Orthopsychiatric Association	1	8328	0	9257	9257	0.8996435130171762	american-orthopsychiatric-association
+American Osteopathic Association	1	16	0	954	954	0.016771488469601678	american-osteopathic-association
+American Paraplegia Society	1	3	0	0	275	0.01090909090909091	american-paraplegia-society
+American Pharmaceutical Association	2	5559	0	0	5787	0.9606013478486263	american-pharmaceutical-association
+American Pharmacists Association	2	10125	0	0	10127	0.9998025081465389	american-pharmacists-association
+American Philosophical Society	2	1080	0	1088	1088	0.9926470588235294	american-philosophical-society
+American Physical Society	19	555125	3628	282508	557614	0.9955363387576353	american-physical-society
+American Physical Therapy Association	1	1233	0	0	1247	0.9887730553327987	american-physical-therapy-association
+American Physiological Society	15	41507	965	55287	60506	0.6859980828347602	american-physiological-society
+American Phytopathological Society	3	11417	0	32591	32591	0.3503114356724249	american-phytopathological-society
+American Planning Association	1	2246	0	0	2247	0.9995549621717846	american-planning-association
+American Podiatric Medical Association	1	2402	0	5933	5933	0.40485420529243216	american-podiatric-medical-association
+American Political Science Association	1	407	0	0	407	1.0	american-political-science-association
+American Protestant Health Association	1	140	0	0	140	1.0	american-protestant-health-association
+American Psychiatric Association	1	20885	0	24421	24421	0.8552065844969493	american-psychiatric-association
+American Psychiatric Publishing, Inc.	2	43581	0	49224	49224	0.8853607996099464	american-psychiatric-publishing-inc
+American Psychological Association	75	147816	389	200324	220982	0.6689051596962649	american-psychological-association
+American Public Health Association	2	36296	0	19401	37712	0.9624522698345355	american-public-health-association
+American Real Estate Society	1	41	0	41	41	1.0	american-real-estate-society
+American Roentgen Ray Society	1	28249	0	31394	31394	0.8998216219659808	american-roentgen-ray-society
+American School of Classical Studies	1	1557	0	1752	1752	0.8886986301369864	american-school-of-classical-studies
+American Schools of Oriental Research	2	2933	0	3013	3013	0.9734483903086625	american-schools-of-oriental-research
+American Scientific Publishers	18	20701	0	38015	38190	0.5420528934275989	american-scientific-publishers
+American Society for Aesthetic Plastic Surgery	1	1	0	0	31	0.03225806451612903	american-society-for-aesthetic-plastic-surgery
+American Society for Biochemistry and Molecular Biology Inc.	4	112039	0	109364	114089	0.9820315718430348	american-society-for-biochemistry-and-molecular-biology-inc
+American Society for Cell Biology	3	9741	944	9856	9858	0.9881314668289713	american-society-for-cell-biology
+American Society for Clinical Investigation	1	737	0	32033	32033	0.023007523491399496	american-society-for-clinical-investigation
+American Society for Clinical Nutrition, Inc.	1	3884	0	3906	3906	0.9943676395289298	american-society-for-clinical-nutrition-inc
+American Society for Engineering Education	1	0	0	36	36	0.0	american-society-for-engineering-education
+American Society for Enology and Viticulture	1	419	0	431	431	0.9721577726218097	american-society-for-enology-and-viticulture
+American Society for Environmental History	1	117	0	0	117	1.0	american-society-for-environmental-history
+American Society for Horitcultural Science	3	175	0	238	238	0.7352941176470589	american-society-for-horitcultural-science
+American Society for Information Science & Technology	2	1291	0	0	1295	0.9969111969111969	american-society-for-information-science-technology
+American Society for Metals	4	2275	0	0	2275	1.0	american-society-for-metals
+American Society for Microbiology	17	145875	2152	162470	162471	0.8978525398378787	american-society-for-microbiology
+American Society for Nutrition	1	652	0	654	654	0.9969418960244648	american-society-for-nutrition
+American Society for Nutritional Sciences	1	2840	0	2864	2864	0.9916201117318436	american-society-for-nutritional-sciences
+American Society for Pharmacology and Experimental Therapeutics	5	15833	0	15945	16452	0.962375395088743	american-society-for-pharmacology-and-experimental-therapeutics
+American Society for Photogrammetry and Remote Sensing	1	1142	0	1207	1207	0.9461474730737366	american-society-for-photogrammetry-and-remote-sensing
+American Society for Testing and Materials	8	10	0	7227	10699	9.346667912889055e-4	american-society-for-testing-and-materials
+American Society of Agricultural and Biological Engineers	2	60	0	2263	2273	0.026396832380114386	american-society-of-agricultural-and-biological-engineers
+American Society of Agricultural Engineers	2	2	0	431	431	0.004640371229698376	american-society-of-agricultural-engineers
+American Society of Agronomy, Inc.	3	539	0	24743	25769	0.02091660522333036	american-society-of-agronomy-inc
+American Society of Andrology	1	1955	0	0	1958	0.998467824310521	american-society-of-andrology
+American Society of Animal Science	1	1198	0	20705	20705	0.0578604201883603	american-society-of-animal-science
+American Society of Brewing Chemists	1	37	0	2762	2762	0.013396089790007242	american-society-of-brewing-chemists
+American Society of Civil Engineers	35	71573	0	68131	72491	0.9873363589962892	american-society-of-civil-engineers
+American Society of Clinical Oncology	3	18590	0	55526	55526	0.33479811259590103	american-society-of-clinical-oncology
+American Society of Comparative Law	1	3697	0	5191	5191	0.7121941822384897	american-society-of-comparative-law
+American Society of Consultant Pharmacists	1	406	0	1008	1008	0.4027777777777778	american-society-of-consultant-pharmacists
+American Society of Contemporary Medicine, Surgery and Opthalmology	2	878	0	0	929	0.9451022604951561	american-society-of-contemporary-medicine-surgery-and-opthalmology
+American Society of Electroneurodiagnostic Technologists, Inc.	1	2	0	0	13	0.15384615384615385	american-society-of-electroneurodiagnostic-technologists-inc
+American Society of Experimental Neurotherapeutics	1	195	0	0	195	1.0	american-society-of-experimental-neurotherapeutics
+American Society of Health-System Pharmacists	1	4530	0	4741	4741	0.9554946213878929	american-society-of-health-system-pharmacists
+American Society of Heating, Refrigerating and Air Conditioning Engineers	1	799	0	0	799	1.0	american-society-of-heating-refrigerating-and-air-conditioning-engineers
+American Society of Hematology	2	25747	1100	26015	26015	0.9896982510090333	american-society-of-hematology
+American Society of Ichthyologists and Herpetologists	1	13089	0	13108	13108	0.9985505035093073	american-society-of-ichthyologists-and-herpetologists
+American Society of Mammalogists	1	846	0	898	898	0.9420935412026726	american-society-of-mammalogists
+American Society of Mechanical Engineers	28	50611	0	77901	81679	0.6196329533907124	american-society-of-mechanical-engineers
+American Society of Naval Engineers	1	6019	0	0	6019	1.0	american-society-of-naval-engineers
+American Society of Nephrology	2	8848	0	8928	8928	0.9910394265232975	american-society-of-nephrology
+American Society of Neuoradiology	1	4538	0	4588	4588	0.9891020052310375	american-society-of-neuoradiology
+American Society of Ophthalmic Registered Nurses	1	384	0	385	385	0.9974025974025974	american-society-of-ophthalmic-registered-nurses
+American Society of Parasitology	1	17573	0	17648	17648	0.9957502266545785	american-society-of-parasitology
+American Society of Plant Biologists	2	37670	0	39948	39948	0.942975868629218	american-society-of-plant-biologists
+American Society of Plant Taxonomists	1	2601	0	2621	2621	0.9923693246852346	american-society-of-plant-taxonomists
+American Society of Transportation and Logistics	1	211	0	226	226	0.9336283185840708	american-society-of-transportation-and-logistics
+American Society of Tropical Medicine and Hygiene	1	3449	0	3593	3593	0.9599220706930142	american-society-of-tropical-medicine-and-hygiene
+American Sociological Association	2	1428	0	0	1428	1.0	american-sociological-association
+American Speech-Language-Hearing Association	6	4803	0	11611	14327	0.3352411530676345	american-speech-language-hearing-association
+American Telephone and Telegraph Co.	1	4448	0	0	4450	0.9995505617977528	american-telephone-and-telegraph-co
+American Thoracic Society	5	26760	0	21314	27344	0.978642480983031	american-thoracic-society
+American University	1	121	0	0	121	1.0	american-university
+American Vacuum Society	1	544	594	594	594	0.9158249158249159	american-vacuum-society
+American Veterinary Medical Association	2	10450	0	10786	10786	0.9688485073243093	american-veterinary-medical-association
+American Water Works Association	1	0	0	205	205	0.0	american-water-works-association
+AMS Press	2	133	0	0	228	0.5833333333333334	ams-press
+Amsterdam University Press	1	48	0	112	112	0.42857142857142855	amsterdam-university-press
+Anadolu University	2	0	177	184	184	0.0	anadolu-university
+Anatomical Society of India	1	973	0	995	995	0.9778894472361809	anatomical-society-of-india
+Anderson Publishing Ltd.	1	0	0	320	320	0.0	anderson-publishing-ltd
+Andrologie - Med - Editions	1	986	0	0	986	1.0	andrologie-med-editions
+Angelo Pontecorboli Editore	2	1249	0	667	1249	1.0	angelo-pontecorboli-editore
+ANI Publishing	1	0	0	217	217	0.0	ani-publishing
+Animal Nutrition Association	1	1	0	136	136	0.007352941176470588	animal-nutrition-association
+Ankara Microbiology Society	1	0	0	275	275	0.0	ankara-microbiology-society
+Ankara Universitesi	3	397	656	3397	3925	0.10114649681528662	ankara-universitesi
+Ankara University	2	1	1259	1592	1592	6.28140703517588e-4	ankara-university
+Ankara University Faculty of Education Department Primary Education	1	0	0	218	218	0.0	ankara-university-faculty-of-education-department-primary-education
+Ankho International Inc.	1	46	0	0	46	1.0	ankho-international-inc
+Annals of Family Medicine, Inc.	1	1739	1822	1822	1822	0.9544456641053787	annals-of-family-medicine-inc
+Annual Reviews, inc.	55	34196	0	36873	42859	0.7978720922093376	annual-reviews-inc
+ANSInet	6	1	0	0	1419	7.047216349541931e-4	ansinet
+Anthropological Society Of New South Wales	1	1051	0	0	1051	1.0	anthropological-society-of-new-south-wales
+Anthropological Society of Nippon	1	0	0	0	2649	0.0	anthropological-society-of-nippon
+Antioch Review, Inc.	1	6218	0	6503	6503	0.9561740735045363	antioch-review-inc
+AOAC International	1	1130	0	1324	1324	0.8534743202416919	aoac-international
+Aple Editores SA	1	0	0	0	293	0.0	aple-editores-sa
+Apollo Books	1	841	0	0	842	0.998812351543943	apollo-books
+Appalachian State University	1	6802	0	0	6815	0.998092443140132	appalachian-state-university
+Arab Society for Plant Protection	1	0	0	20	20	0.0	arab-society-for-plant-protection
+Arab Society of Nephrology and Renal Transplantation	1	0	0	0	62	0.0	arab-society-of-nephrology-and-renal-transplantation
+Arachnological Society of Japan	1	2	0	1000	1000	0.002	arachnological-society-of-japan
+Arachnologische Arbeitsgemeinschaften Deutschlands	1	15	650	650	650	0.023076923076923078	arachnologische-arbeitsgemeinschaften-deutschlands
+Aran Ediciones SA	6	1047	2835	3535	5503	0.1902598582591314	aran-ediciones-sa
+Aras Part Medical International Press	1	1	0	180	180	0.005555555555555556	aras-part-medical-international-press
+Archaeological Institute of America	1	10115	0	10487	10487	0.9645275102507866	archaeological-institute-of-america
+Architectural Institute of Japan	4	5877	0	15132	15132	0.38838223632038066	architectural-institute-of-japan
+Archives & Museum Informatics	1	431	0	0	431	1.0	archives-museum-informatics
+Archives of American Art	1	136	0	1275	1275	0.10666666666666667	archives-of-american-art
+Arctic Institute of North America	1	1	0	4479	4479	2.2326412145568208e-4	arctic-institute-of-north-america
+Argentinean Association of Computational Mechanics	1	2	585	585	585	0.003418803418803419	argentinean-association-of-computational-mechanics
+Argumentum Kiado	1	0	0	104	104	0.0	argumentum-kiado
+Arizona State University	2	27	1178	1985	1985	0.013602015113350126	arizona-state-university
+Arkansas Historical Association	1	2227	0	0	2227	1.0	arkansas-historical-association
+Arkat USA	1	35	3900	3900	3900	0.008974358974358974	arkat-usa
+Armand Colin Editeur	6	46	2931	9083	10997	0.004182958988815131	armand-colin-editeur
+Armed Forces Hospital	1	1	0	130	130	0.007692307692307693	armed-forces-hospital
+Array Development	1	0	0	0	59	0.0	array-development
+Ars Brevis Foundation, Inc.	1	477	0	1253	1253	0.38068635275339185	ars-brevis-foundation-inc
+Art Institute of Chicago	1	394	0	0	394	1.0	art-institute-of-chicago
+Articulo	1	1	166	166	166	0.006024096385542169	articulo
+ASEAN Federation of Endocrine Societies (AFES)	1	0	203	203	203	0.0	asean-federation-of-endocrine-societies-afes
+ASERS Publishing	1	5	0	8	8	0.625	asers-publishing
+Ashdin Publishing	1	1	0	64	64	0.015625	ashdin-publishing
+Ashley Publications Ltd.	2	2645	0	2602	2700	0.9796296296296296	ashley-publications-ltd
+Asian Academy of Management and Universiti Sains Malasia	1	0	16	16	16	0.0	asian-academy-of-management-and-universiti-sains-malasia
+Asian Agricultural and Biological Engineering Association	1	304	0	310	310	0.9806451612903225	asian-agricultural-and-biological-engineering-association
+Asian Association of Oral and Maxillofacial	1	460	0	0	460	1.0	asian-association-of-oral-and-maxillofacial
+Asian Journal of Pharmaceutical and Clinical Research	1	0	57	57	57	0.0	asian-journal-of-pharmaceutical-and-clinical-research
+Asian Media Information and Communication Centre	1	628	0	0	1627	0.3859864781807007	asian-media-information-and-communication-centre
+Asian Network for Scientific Information	30	3082	243	22589	37592	0.08198552883592254	asian-network-for-scientific-information
+Asian Pacific Organization for Cancer Prevention	1	71	0	6049	6049	0.011737477268970078	asian-pacific-organization-for-cancer-prevention
+Asian-Australasian Association of Animal Production Societies	1	68	0	5630	5630	0.012078152753108348	asian-australasian-association-of-animal-production-societies
+Aslib	1	2755	0	0	2818	0.9776437189496097	aslib
+ASM International	4	11585	0	1930	11708	0.989494362828835	asm-international
+Asociacion Andaluza de Medicos Forenses	1	0	0	355	355	0.0	asociacion-andaluza-de-medicos-forenses
+Asociacion Cavelier Del Derecho, Universidad del Rosario	1	0	36	36	36	0.0	asociacion-cavelier-del-derecho-universidad-del-rosario
+Asociacion Colombiana de Infectologia	1	342	0	342	342	1.0	asociacion-colombiana-de-infectologia
+Asociacion De Antropologos Iberoamericanos En Red - AIBR	1	0	248	248	248	0.0	asociacion-de-antropologos-iberoamericanos-en-red-aibr
+Asociacion de Biologos de la Universidad Nacional Mayor de San Marcos	1	1	962	962	962	0.0010395010395010396	asociacion-de-biologos-de-la-universidad-nacional-mayor-de-san-marcos
+Asociacion de Ciencias Naturales del Litoral	1	0	0	0	677	0.0	asociacion-de-ciencias-naturales-del-litoral
+Asociacion de Geografos Espanoles	1	0	0	37	37	0.0	asociacion-de-geografos-espanoles
+Asociacion de Licenciados en Ciencia e Tecnoloxia dos Alimentos de Galicia	1	221	0	0	221	1.0	asociacion-de-licenciados-en-ciencia-e-tecnoloxia-dos-alimentos-de-galicia
+Asociacion Espanola de Andrologia	1	459	0	465	465	0.9870967741935484	asociacion-espanola-de-andrologia
+Asociacion Espanola de Ciencia politica y de la Administracion	1	0	0	20	20	0.0	asociacion-espanola-de-ciencia-politica-y-de-la-administracion
+Asociacion Espanola de Ecologia Terrestre	1	0	0	186	186	0.0	asociacion-espanola-de-ecologia-terrestre
+Asociacion Espanola de Inteligencia Artificial	1	0	445	445	445	0.0	asociacion-espanola-de-inteligencia-artificial
+Asociacion Espanola De Logopedia Foniatria Y Audiologia	1	1062	0	1065	1065	0.9971830985915493	asociacion-espanola-de-logopedia-foniatria-y-audiologia
+Asociacion Espanola de Micologia	1	653	0	661	661	0.9878971255673222	asociacion-espanola-de-micologia
+Asociacion Espanola de Orientacion y Psicopedagogia	1	1	0	230	230	0.004347826086956522	asociacion-espanola-de-orientacion-y-psicopedagogia
+Asociacion Espanola de Pediatria	1	0	598	598	598	0.0	asociacion-espanola-de-pediatria
+Asociacion Espanola de Psicologia Clinica y Psicopatologia	1	0	0	409	409	0.0	asociacion-espanola-de-psicologia-clinica-y-psicopatologia
+Asociacion Espanola de Teledeteccion	1	0	72	72	72	0.0	asociacion-espanola-de-teledeteccion
+Asociacion Europes de Direccion y Economia de la Empresa	1	75	0	0	75	1.0	asociacion-europes-de-direccion-y-economia-de-la-empresa
+Asociacion Internacional de Derecho Cooperativo	1	0	187	187	187	0.0	asociacion-internacional-de-derecho-cooperativo
+Asociacion Interprofesional Desarrollo Agario	1	0	123	123	123	0.0	asociacion-interprofesional-desarrollo-agario
+Asociacion Interuniversitaria de Investigacion en Pedagogia	1	1	142	142	142	0.007042253521126761	asociacion-interuniversitaria-de-investigacion-en-pedagogia
+Asociacion Mexicana de Mastozoologia	1	3	0	287	287	0.010452961672473868	asociacion-mexicana-de-mastozoologia
+Asociacion Nacional de Universidades e Instituciones de Educacion Superior A.C	1	98	104	104	104	0.9423076923076923	asociacion-nacional-de-universidades-e-instituciones-de-educacion-superior-a-c
+Associacao Arquivos de Neuro-Psiquiatria Dr. Oswaldo Lange	1	25	6757	6757	6757	0.0036998668047950275	associacao-arquivos-de-neuro-psiquiatria-dr-oswaldo-lange
+Associacao Brasileira da Soldagem	1	0	30	30	30	0.0	associacao-brasileira-da-soldagem
+Associacao Brasileira de Divulgacao Cientifica	2	32	1909	1909	1909	0.01676270298585647	associacao-brasileira-de-divulgacao-cientifica
+Associacao Brasileira de Enfermagem	1	3	224	224	224	0.013392857142857142	associacao-brasileira-de-enfermagem
+Associacao Brasileira de Engenharia de Producao	1	7	700	700	700	0.01	associacao-brasileira-de-engenharia-de-producao
+Associacao Brasileira de Engenharia Sanitaria e Ambiental	1	1	441	441	441	0.0022675736961451248	associacao-brasileira-de-engenharia-sanitaria-e-ambiental
+Associacao Brasileira de Estatistica	1	215	250	250	250	0.86	associacao-brasileira-de-estatistica
+Associacao Brasileira De Estudos Populacionais	1	0	360	360	360	0.0	associacao-brasileira-de-estudos-populacionais
+Associacao Brasileira de Pos-Graduacao em Saude Coletiva	2	8	3474	3474	3474	0.002302820955670697	associacao-brasileira-de-pos-graduacao-em-saude-coletiva
+Associacao Brasileira de Psicologia Escolar e Educacional (ABRAPEE)	1	0	782	782	782	0.0	associacao-brasileira-de-psicologia-escolar-e-educacional-abrapee
+Associacao Brasileira de Psicologia Social	1	0	500	500	500	0.0	associacao-brasileira-de-psicologia-social
+Associacao Brasileira de Psiquiatria	1	161	452	452	452	0.3561946902654867	associacao-brasileira-de-psiquiatria
+Associacao Brasileira de Tecnologia de Sementes	2	5	47	47	1805	0.002770083102493075	associacao-brasileira-de-tecnologia-de-sementes
+Associacao Brasileiro de Ceramica	1	9	1020	1020	1020	0.008823529411764706	associacao-brasileiro-de-ceramica
+Associacao de Apoio a Pesquisa em Saude Bucal - APESB	1	1	601	601	601	0.0016638935108153079	associacao-de-apoio-a-pesquisa-em-saude-bucal-apesb
+Associacao de Medicina Intensiva Brasileira	1	6	786	786	786	0.007633587786259542	associacao-de-medicina-intensiva-brasileira
+Associacao de Psiquiatria do Rio Grande do Sul	1	0	25	25	25	0.0	associacao-de-psiquiatria-do-rio-grande-do-sul
+Associacao Iberica de Sistemas e Tecnologias de Informacao (AISTI)	1	0	136	136	136	0.0	associacao-iberica-de-sistemas-e-tecnologias-de-informacao-aisti
+Associacao Nacional de Medicina do Trabalho	1	0	0	32	32	0.0	associacao-nacional-de-medicina-do-trabalho
+Associacao Nacional de Pos-Graduacao e Pesquisa em Administracao	1	0	206	206	206	0.0	associacao-nacional-de-pos-graduacao-e-pesquisa-em-administracao
+Associacao Nacional de Pos-Graduacao e Pesquisa em Ciencias Sociais	1	0	779	779	779	0.0	associacao-nacional-de-pos-graduacao-e-pesquisa-em-ciencias-sociais
+Associacao Nacional de Pos-graduacao e Pesquisa em Educacao	1	1	856	856	856	0.0011682242990654205	associacao-nacional-de-pos-graduacao-e-pesquisa-em-educacao
+Associacao Nacional dos Professores Universitarios de Historia, ANPUH	1	0	1	1	1	0.0	associacao-nacional-dos-professores-universitarios-de-historia-anpuh
+Associacao Neurologia Cognitiva e do Comportamento	1	0	552	552	552	0.0	associacao-neurologia-cognitiva-e-do-comportamento
+Associacao Paranaense de Historia	1	0	0	0	399	0.0	associacao-paranaense-de-historia
+Associacao Paulista de Medicina	1	7	116	116	116	0.0603448275862069	associacao-paulista-de-medicina
+Associacao Portuguesa de Psicologia	1	0	0	472	472	0.0	associacao-portuguesa-de-psicologia
+Associacao Profissional de Conservadores, Restauradores de Portugal	1	0	80	80	80	0.0	associacao-profissional-de-conservadores-restauradores-de-portugal
+Associacao Universitaria de Pesquisa em Psicopatologia Fundamental	1	0	13	13	13	0.0	associacao-universitaria-de-pesquisa-em-psicopatologia-fundamental
+Associacio Catalana de Meteorologia (ACAM)	1	0	63	63	63	0.0	associacio-catalana-de-meteorologia-acam
+Associacion Espanola de Economia Agraria	1	0	0	243	243	0.0	associacion-espanola-de-economia-agraria
+Associated Management Consultants Private Limited	3	0	0	1305	1305	0.0	associated-management-consultants-private-limited
+Association 'Rus'	1	0	0	136	136	0.0	association-rus
+Association Amici Thomae Mori	1	15	0	0	1390	0.01079136690647482	association-amici-thomae-mori
+Association Archipel	1	6	0	1091	1091	0.005499541704857928	association-archipel
+Association Carnets de Geologie	1	0	247	247	247	0.0	association-carnets-de-geologie
+Association de Geographes Francais	1	0	0	2634	2634	0.0	association-de-geographes-francais
+Association des Annales de I'Institut Fourier	1	12	0	3076	3076	0.0039011703511053317	association-des-annales-de-iinstitut-fourier
+Association des Bibliothecaires Francais	1	0	0	1762	1762	0.0	association-des-bibliothecaires-francais
+Association des demographes du Quebec	1	611	0	0	919	0.6648531011969532	association-des-demographes-du-quebec
+Association des Pharmaciens - Anciens Eleves - Amis de la Faculte de Pharmacie de Lyon	1	0	0	0	5	0.0	association-des-pharmaciens-anciens-eleves-amis-de-la-faculte-de-pharmacie-de-lyon
+Association des Professeurs de Langues des Instituts Universitaires de Technologie (APLIUT)	1	0	0	443	443	0.0	association-des-professeurs-de-langues-des-instituts-universitaires-de-technologie-apliut
+Association for Computing Machinery	49	41013	0	46539	47900	0.8562212943632568	association-for-computing-machinery
+Association for Dental Sciences of the Republic of China	1	546	0	555	555	0.9837837837837838	association-for-dental-sciences-of-the-republic-of-china
+Association for Education in Journalism and Mass Communication	1	121	0	127	127	0.952755905511811	association-for-education-in-journalism-and-mass-communication
+Association for Educational Communications and Technology	1	6	0	0	6	1.0	association-for-educational-communications-and-technology
+Association for Fire Ecology	1	2	0	268	268	0.007462686567164179	association-for-fire-ecology
+Association for Humanistic Education and Development	1	272	0	0	452	0.6017699115044248	association-for-humanistic-education-and-development
+Association for International Agricultural and Extension Education	1	0	0	405	405	0.0	association-for-international-agricultural-and-extension-education
+Association for Investment Management and Research	1	7	0	4860	4860	0.001440329218106996	association-for-investment-management-and-research
+Association for Laboratory Automation	1	1300	0	0	1455	0.8934707903780069	association-for-laboratory-automation
+Association for Persons with Severe Handicaps	1	225	0	0	226	0.995575221238938	association-for-persons-with-severe-handicaps
+Association for Research in Vision and Ophthalmology	2	1439	23132	23628	23628	0.06090231928220755	association-for-research-in-vision-and-ophthalmology
+Association for Social Studies Educators (ASSE)	1	0	25	25	25	0.0	association-for-social-studies-educators-asse
+Association for the Advancement of Medical Instrumentation	1	1570	0	2111	2111	0.7437233538607295	association-for-the-advancement-of-medical-instrumentation
+Association for the Development of Science, Engineering and Education	1	0	20	20	20	0.0	association-for-the-development-of-science-engineering-and-education
+Association for the Sociology of Religion	1	1758	0	1815	1815	0.968595041322314	association-for-the-sociology-of-religion
+Association for Vascular Access	1	485	0	0	501	0.9680638722554891	association-for-vascular-access
+Association Francaise des Documentalistes et des Bibliothecaires Specialises	1	5	0	639	639	0.00782472613458529	association-francaise-des-documentalistes-et-des-bibliothecaires-specialises
+Association Francaise Pour La Sauvegarde De L Enfance Et De L Adolescence	1	68	0	0	68	1.0	association-francaise-pour-la-sauvegarde-de-l-enfance-et-de-l-adolescence
+Association generale des hygienistes et techniciens municipaux	1	1	0	596	596	0.0016778523489932886	association-generale-des-hygienistes-et-techniciens-municipaux
+Association Internationale des Etudes Francaises	1	1	0	1162	1162	8.605851979345956e-4	association-internationale-des-etudes-francaises
+Association Inuksiutiit Katimajiit	1	273	0	470	470	0.5808510638297872	association-inuksiutiit-katimajiit
+Association Multitudes	1	10	0	1550	1550	0.0064516129032258064	association-multitudes
+Association of American Geographers	1	32	0	1128	1128	0.028368794326241134	association-of-american-geographers
+Association of American Medical Colleges	1	158	0	0	185	0.8540540540540541	association-of-american-medical-colleges
+Association of Avian Veterinarians	1	857	0	882	882	0.971655328798186	association-of-avian-veterinarians
+Association of Biomolecular Resource Facilities	1	2	111	111	111	0.018018018018018018	association-of-biomolecular-resource-facilities
+Association of College and Research Libraies	1	921	6839	6839	6839	0.13466881122971194	association-of-college-and-research-libraies
+Association of Geographical Societies of Slovenia	1	0	0	40	40	0.0	association-of-geographical-societies-of-slovenia
+Association of Japanese Geographers	1	0	0	0	239	0.0	association-of-japanese-geographers
+Association of Military Surgeons of the US	1	723	0	3855	3855	0.18754863813229572	association-of-military-surgeons-of-the-us
+Association of Otolaryngologists of India	2	1706	0	856	1712	0.9964953271028038	association-of-otolaryngologists-of-india
+Association of Pharmaceutical Innovators	1	55	0	55	55	1.0	association-of-pharmaceutical-innovators
+Association of Pharmaceutical Teachers of India	1	5	0	265	265	0.018867924528301886	association-of-pharmaceutical-teachers-of-india
+Association of Rehabilitation Nurses	1	65	0	0	65	1.0	association-of-rehabilitation-nurses
+Association of the Chemical Engineers	1	336	654	654	654	0.5137614678899083	association-of-the-chemical-engineers
+Association Paleontologica Argentina	1	359	0	412	412	0.8713592233009708	association-paleontologica-argentina
+Association pharmaceutique francaise pour l'hydrologie	1	0	0	0	364	0.0	association-pharmaceutique-francaise-pour-lhydrologie
+Association pour I'Etude des Migrations Internationales	1	4	0	0	997	0.004012036108324975	association-pour-ietude-des-migrations-internationales
+Association Pour la Prevention de la Pollution Atmospherique	1	0	0	0	352	0.0	association-pour-la-prevention-de-la-pollution-atmospherique
+Association Recherches de Science Religieuse	1	0	0	13	13	0.0	association-recherches-de-science-religieuse
+Association Regionale pour la Sauvegarde de l'Enfant, de l'Adolescent et de l'Adulte (ARSEAA)	1	3	0	1690	1690	0.0017751479289940828	association-regionale-pour-la-sauvegarde-de-lenfant-de-ladolescent-et-de-ladulte-arseaa
+Association scientifique Europeenne pour l'eau et la sante	1	0	0	0	154	0.0	association-scientifique-europeenne-pour-leau-et-la-sante
+Association Scientifique pour la Geologie et ses Applications	1	155	0	0	155	1.0	association-scientifique-pour-la-geologie-et-ses-applications
+Associazione Istituto di Genetica Medica e Gemellologia Gregorio Mendel	1	542	0	0	1078	0.5027829313543599	associazione-istituto-di-genetica-medica-e-gemellologia-gregorio-mendel
+Associazione Italiana di Telerilevamento	1	6	223	223	223	0.026905829596412557	associazione-italiana-di-telerilevamento
+Associazione per la Matematica Applicata alle Scienze Economiche e Sociali	1	10	0	0	10	1.0	associazione-per-la-matematica-applicata-alle-scienze-economiche-e-sociali
+Asthma Publication Society	1	522	0	0	525	0.9942857142857143	asthma-publication-society
+Astronomical Observatory	1	121	353	353	353	0.34277620396600567	astronomical-observatory
+Astronomical Society of Korea	1	0	519	519	519	0.0	astronomical-society-of-korea
+AT & T	1	118	0	0	118	1.0	at-t
+Ataturk Universitesi	1	0	0	111	111	0.0	ataturk-universitesi
+Ateneo de Manila University	3	38	56	263	272	0.13970588235294118	ateneo-de-manila-university
+Athabasca University	1	0	1036	1036	1036	0.0	athabasca-university
+Atlantic Geoscience Society	1	15	0	43	43	0.3488372093023256	atlantic-geoscience-society
+Atlantis Press	2	774	0	1193	1193	0.6487845766974015	atlantis-press
+Atlas- Clusium	1	0	0	21	21	0.0	atlas-clusium
+Atomic Energy Society of Japan/Nihon Genshiroku Gakkai	2	0	0	542	4320	0.0	atomic-energy-society-of-japan-nihon-genshiroku-gakkai
+Auckland University of Technology	2	1	11	231	231	0.004329004329004329	auckland-university-of-technology
+Audio Engineering Society	1	0	0	197	197	0.0	audio-engineering-society
+Auerbach Publications	1	472	0	0	474	0.9957805907172996	auerbach-publications
+Augustin Verlag	1	10	0	0	10	1.0	augustin-verlag
+Australasian College for Infection Prevention and Control (ACIPC)	1	160	0	164	164	0.975609756097561	australasian-college-for-infection-prevention-and-control-acipc
+Australasian Medical Publishing Company	1	15	0	3380	3380	0.004437869822485207	australasian-medical-publishing-company
+Australasian Society of Cardiac and Thoracic Surgeons	1	94	0	0	94	1.0	australasian-society-of-cardiac-and-thoracic-surgeons
+Australasian Universities Language and Literature Association	1	924	0	0	1071	0.8627450980392157	australasian-universities-language-and-literature-association
+Australian Academic Press Pty Ltd.	2	800	0	0	935	0.8556149732620321	australian-academic-press-pty-ltd
+Australian Academy of the Humanities and the History of Ideas Unit	1	51	0	0	53	0.9622641509433962	australian-academy-of-the-humanities-and-the-history-of-ideas-unit
+Australian Agricultural Economics Society	1	731	0	0	731	1.0	australian-agricultural-economics-society
+Australian and New Zealand College of Mental Health Nurses	1	90	0	0	90	1.0	australian-and-new-zealand-college-of-mental-health-nurses
+Australian College of Midwives	2	741	0	0	741	1.0	australian-college-of-midwives
+Australian Council on the Ageing	1	702	0	0	702	1.0	australian-council-on-the-ageing
+Australian Group for the Scientific Study of Mental Deficiency	2	406	0	0	426	0.9530516431924883	australian-group-for-the-scientific-study-of-mental-deficiency
+Australian Health Promotion Association	1	99	0	251	251	0.3944223107569721	australian-health-promotion-association
+Australian Institute of International Affairs	1	1422	0	0	1427	0.9964961457603364	australian-institute-of-international-affairs
+Australian Institute of Political Science	2	3819	0	0	3819	1.0	australian-institute-of-political-science
+Australian International Academic Centre PTY. LTD.	1	0	1010	0	1010	0.0	australian-international-academic-centre-pty-ltd
+Australian Mathematical Society	1	1009	0	0	1012	0.9970355731225297	australian-mathematical-society
+Australian Meteorological and Oceanographic Society	1	0	0	242	242	0.0	australian-meteorological-and-oceanographic-society
+Australian Museum	1	5	0	0	1322	0.0037821482602118004	australian-museum
+Australian Petroleum Production and Exploration Association	1	1	0	0	12	0.08333333333333333	australian-petroleum-production-and-exploration-association
+Australian Physiotherapy Association	2	2088	604	604	2104	0.9923954372623575	australian-physiotherapy-association
+Australian Population Association	1	71	0	0	71	1.0	australian-population-association
+Australian Society for Educational Technology	1	0	1083	1083	1083	0.0	australian-society-for-educational-technology
+Australian Society for the History of Medicine	1	445	0	0	505	0.8811881188118812	australian-society-for-the-history-of-medicine
+Australian Society for the Study of Labour History	1	2576	0	2651	2651	0.971708789136175	australian-society-for-the-study-of-labour-history
+Austrian Academy of Sciences	2	2	0	352	352	0.005681818181818182	austrian-academy-of-sciences
+Austrian Society for Statistics	1	0	79	79	79	0.0	austrian-society-for-statistics
+Aux Amateurs de Livres	1	0	0	690	690	0.0	aux-amateurs-de-livres
+Avances En Odontoestomatologia	1	1	340	340	340	0.0029411764705882353	avances-en-odontoestomatologia
+AVES Ibrahim Kara	11	1992	0	3238	4462	0.44643657552666965	aves-ibrahim-kara
+Aves Yayincilik	1	29	288	288	288	0.10069444444444445	aves-yayincilik
+Aviation/Hospital Consultants	1	883	0	0	883	1.0	aviation-hospital-consultants
+Avicena Publishing	1	4	473	473	473	0.008456659619450317	avicena-publishing
+Avondale Academic Press	1	0	0	0	1388	0.0	avondale-academic-press
+AVS Science and Technology Society	1	2370	0	2616	2616	0.9059633027522935	avs-science-and-technology-society
+B.C. Decker Inc.	7	13424	0	0	14144	0.9490950226244343	b-c-decker-inc
+Babes-Bolyai University	1	0	10	10	10	0.0	babes-bolyai-university
+Baerenreiter Verlag	1	987	0	987	987	1.0	baerenreiter-verlag
+Bahrain Medical Society	1	0	0	220	220	0.0	bahrain-medical-society
+Baikal'skii Gosudarstvennyi Universitet	1	0	0	141	141	0.0	baikalskii-gosudarstvennyi-universitet
+Bailey-Matthews Shell Museum	1	0	0	198	198	0.0	bailey-matthews-shell-museum
+Baishideng Publishing Group	3	52	1709	1709	1709	0.030427150380339378	baishideng-publishing-group
+Bakirkoy Research and Training Hospital for Psychiatry, Neurology and Neurosurgery	1	222	461	461	461	0.48156182212581344	bakirkoy-research-and-training-hospital-for-psychiatry-neurology-and-neurosurgery
+Bangladesh Association for Plant Tissue Culture and Biotechnology (BAPTC&B)	1	1	0	271	271	0.0036900369003690036	bangladesh-association-for-plant-tissue-culture-and-biotechnology-baptc-b
+Bangladesh Association of Plant Taxonomists	1	2	280	280	280	0.007142857142857143	bangladesh-association-of-plant-taxonomists
+Bangladesh Botanical Society	1	1	341	341	341	0.002932551319648094	bangladesh-botanical-society
+Bangladesh Medical Research Council	1	1	229	229	229	0.004366812227074236	bangladesh-medical-research-council
+Bangladesh Pharmacological Society	1	91	678	678	678	0.13421828908554573	bangladesh-pharmacological-society
+Bangladesh Society of Medicine	1	1	0	467	467	0.0021413276231263384	bangladesh-society-of-medicine
+Bangladesh University of Engineering and Technology	1	29	143	143	143	0.20279720279720279	bangladesh-university-of-engineering-and-technology
+Bard Graduate Center for Studies in the Decorative Arts	1	209	0	0	532	0.39285714285714285	bard-graduate-center-for-studies-in-the-decorative-arts
+Bareilly College	1	1	0	453	453	0.002207505518763797	bareilly-college
+Baskent University	1	1	0	304	304	0.003289473684210526	baskent-university
+Bauman University Publishing House	1	0	0	134	134	0.0	bauman-university-publishing-house
+Baycinar Medical Publishing	1	61	0	214	214	0.2850467289719626	baycinar-medical-publishing
+Baywood Publishing Co., Inc.	4	345	0	1166	2610	0.13218390804597702	baywood-publishing-co-inc
+BCS, The Chartered Institute for IT	2	0	524	497	524	0.0	bcs-the-chartered-institute-for-it
+Becker Associates	1	1035	0	1655	1655	0.6253776435045317	becker-associates
+Beech Tree Publishing	1	556	0	0	557	0.9982046678635548	beech-tree-publishing
+Begell House	35	61	0	21833	23023	0.0026495243886548235	begell-house
+Behavioral Neuropsychiatry	1	1948	0	0	1949	0.9994869163673679	behavioral-neuropsychiatry
+Beijing Institute of Technology	1	0	0	310	310	0.0	beijing-institute-of-technology
+Beijing Linye Daxue/Beijing Forestry University	1	366	0	0	366	1.0	beijing-linye-daxue-beijing-forestry-university
+Beijing University of Posts and Telecommunications	1	1424	0	1434	1434	0.99302649930265	beijing-university-of-posts-and-telecommunications
+Beilstein-Institut	1	255	2142	2142	2142	0.11904761904761904	beilstein-institut
+Beilstein-Institut Zur Forderung der Chemischen Wissenschaften	1	89	1126	1126	1126	0.07904085257548846	beilstein-institut-zur-forderung-der-chemischen-wissenschaften
+Belfort Editora	1	6	2375	2375	2375	0.0025263157894736842	belfort-editora
+BELGEO	1	0	420	420	420	0.0	belgeo
+Bentham	231	34981	7285	80016	85980	0.4068504303326355	bentham
+Berghahn	18	2577	0	4696	4696	0.5487649063032368	berghahn
+Berkeley Electronic Press	2	353	0	390	390	0.9051282051282051	berkeley-electronic-press
+Bernd Oberdorfer, University of Augsburg, Institute of Protestant Theology	1	215	0	256	256	0.83984375	bernd-oberdorfer-university-of-augsburg-institute-of-protestant-theology
+Best Business Books	2	355	0	0	379	0.9366754617414248	best-business-books
+Betriebswirtschaftlicher Verlag Dr. Th. Gabler GmbH	1	824	0	837	837	0.984468339307049	betriebswirtschaftlicher-verlag-dr-th-gabler-gmbh
+Bevilaqua Publisher	1	0	74	74	74	0.0	bevilaqua-publisher
+Bialystok University of Technology	1	68	173	173	173	0.3930635838150289	bialystok-university-of-technology
+Bio-medical Electronics	2	588	0	0	588	1.0	bio-medical-electronics
+Biochemical Society	1	1	0	0	200	0.005	biochemical-society
+Biocommunications Association	1	0	0	0	7	0.0	biocommunications-association
+Bioline International	1	0	0	246	246	0.0	bioline-international
+BioLink Communications	2	1378	0	0	1477	0.932972241029113	biolink-communications
+Biological Society of Washington	2	518	0	476	533	0.9718574108818011	biological-society-of-washington
+Biologicheskie Membrany	1	0	0	211	211	0.0	biologicheskie-membrany
+Biology and Medicine Journal	1	1	229	0	229	0.004366812227074236	biology-and-medicine-journal
+Biology department, Sebelas Maret University Surakarta	1	7	810	810	810	0.008641975308641974	biology-department-sebelas-maret-university-surakarta
+Biomedical Research Foundation	1	28	1624	1624	1624	0.017241379310344827	biomedical-research-foundation
+BioOne	1	3	153	153	153	0.0196078431372549	bioone
+Biophysical Society	1	51928	0	54500	54500	0.9528073394495413	biophysical-society
+Biophysical Society of Japan	1	82	0	129	129	0.6356589147286822	biophysical-society-of-japan
+BioScientifica Ltd.	6	42603	0	50557	50557	0.8426726269359337	bioscientifica-ltd
+Black Sea Universities Network	1	0	0	0	46	0.0	black-sea-universities-network
+Bloomsbury Qatar Foundation Journals	1	144	240	240	240	0.6	bloomsbury-qatar-foundation-journals
+BMJ	50	275713	7960	353296	359289	0.7673850298784544	bmj
+Boccard Edition	1	3	0	368	368	0.008152173913043478	boccard-edition
+Boehlau Verlag GmbH & Cie	3	3283	1582	3926	3926	0.8362200713194091	boehlau-verlag-gmbh-cie
+Bogazici University	1	0	0	112	112	0.0	bogazici-university
+Bogor Agricultural University	1	81	225	225	225	0.36	bogor-agricultural-university
+Bohlau Verlag	2	4370	0	4634	5727	0.7630522088353414	bohlau-verlag
+Bohn Stafleu van Loghum B.V	7	13034	0	10467	13516	0.9643385617046464	bohn-stafleu-van-loghum-b-v
+BOLEMA Departamento de Matematica	1	0	355	355	355	0.0	bolema-departamento-de-matematica
+Bolyaianum Universitatis	1	0	0	127	127	0.0	bolyaianum-universitatis
+Bombay Natural History Society	1	0	0	84	84	0.0	bombay-natural-history-society
+Boom Lemma uitgevers	1	0	0	40	40	0.0	boom-lemma-uitgevers
+Borgis Publishing House	1	0	0	49	49	0.0	borgis-publishing-house
+Boston University	1	202	0	236	236	0.8559322033898306	boston-university
+Botanical Garden-Institute	1	0	0	77	77	0.0	botanical-garden-institute
+Botanical Research Institute of Texas, Inc.	1	0	0	0	1	0.0	botanical-research-institute-of-texas-inc
+Botanical Society of America Inc.	2	14443	419	14567	14567	0.9914876089791995	botanical-society-of-america-inc
+Botanischer Garten and Botanisches Museum Berlin-Dahlem	2	389	0	944	975	0.39897435897435896	botanischer-garten-and-botanisches-museum-berlin-dahlem
+Bowling Green State University in cooperation with the Popular Culture Association and the American Culture Association	1	2263	0	0	2304	0.9822048611111112	bowling-green-state-university-in-cooperation-with-the-popular-culture-association-and-the-american-culture-association
+Boyd Printing	1	4083	0	0	4288	0.9521921641791045	boyd-printing
+Brandes und Apsel Verlag GmbH	2	3	0	1	181	0.016574585635359115	brandes-und-apsel-verlag-gmbh
+Brazilian Administration Review	1	0	297	297	297	0.0	brazilian-administration-review
+Brazilian Aerospace Association - (AAB)	1	0	0	0	81	0.0	brazilian-aerospace-association-aab
+Brazilian Association of Veterinary Pathology	1	0	7	7	7	0.0	brazilian-association-of-veterinary-pathology
+Brazilian Journal of Water Resources	1	0	0	1154	1154	0.0	brazilian-journal-of-water-resources
+Brazilian Microwave and Optoelectronics Society	1	1	199	199	199	0.005025125628140704	brazilian-microwave-and-optoelectronics-society
+Brazilian Society of Chemical Engineering	1	30	1195	1195	1195	0.02510460251046025	brazilian-society-of-chemical-engineering
+Brazilian Society of Floriculture and Ornamental Plants	1	0	0	120	120	0.0	brazilian-society-of-floriculture-and-ornamental-plants
+Brazilian Society of Limnology	1	10	310	310	310	0.03225806451612903	brazilian-society-of-limnology
+Brazilian Society of Mechanical Sciences and Engineering	1	1	0	0	165	0.006060606060606061	brazilian-society-of-mechanical-sciences-and-engineering
+Brazilian Society of Plant Physiology	1	6	0	0	344	0.01744186046511628	brazilian-society-of-plant-physiology
+Brazilian Society of Speech-Language Pathology and Audiology	1	1	432	432	432	0.0023148148148148147	brazilian-society-of-speech-language-pathology-and-audiology
+Brazilian Society of Urology	1	16	2235	2235	2235	0.0071588366890380315	brazilian-society-of-urology
+Brepols Publishers	15	9275	0	15212	15539	0.5968852564515091	brepols-publishers
+Breskin & Charleton Pub. Corp.	1	0	0	0	209	0.0	breskin-charleton-pub-corp
+Brigham Young University	2	716	0	741	1032	0.6937984496124031	brigham-young-university
+Brill	189	150537	10908	165928	177077	0.8501216984701571	brill
+British Arachnological Society (BAS)	1	179	0	185	185	0.9675675675675676	british-arachnological-society-bas
+British Centre for Durkheimian Studies	1	40	0	141	141	0.28368794326241137	british-centre-for-durkheimian-studies
+British Contact Lens Association	1	699	0	0	699	1.0	british-contact-lens-association
+British Editorial Society of Bone and Joint Surgery	3	4703	0	2226	5973	0.7873765277080195	british-editorial-society-of-bone-and-joint-surgery
+British Institute of Non-Destructive Testing	1	1701	0	1877	1877	0.9062333510921684	british-institute-of-non-destructive-testing
+British Institute of Radiology	3	14049	0	28638	29161	0.4817736017283358	british-institute-of-radiology
+British Leprosy Relief Association	1	0	2633	2633	2633	0.0	british-leprosy-relief-association
+British Medical Association	2	19315	0	0	394451	0.04896679181951624	british-medical-association
+British Society for the Study of Mental Subnormality	1	56	0	0	356	0.15730337078651685	british-society-for-the-study-of-mental-subnormality
+British Society of Animal Science	2	4447	0	0	4887	0.9099652138326172	british-society-of-animal-science
+British Trust for Entomology	1	0	0	0	101	0.0	british-trust-for-entomology
+British Veterinary Association	1	19066	0	35424	35424	0.5382226738934056	british-veterinary-association
+Brno University of Technology	1	4	229	229	229	0.017467248908296942	brno-university-of-technology
+Brodarski Institut	1	0	38	38	38	0.0	brodarski-institut
+Brookings Institution Press	2	1607	0	951	1988	0.8083501006036218	brookings-institution-press
+Brown University	1	2	424	424	424	0.0047169811320754715	brown-university
+Bucura Mond Prod Com SRL	1	0	0	373	373	0.0	bucura-mond-prod-com-srl
+Budapest University of Technology and Economics	1	0	0	77	77	0.0	budapest-university-of-technology-and-economics
+Budapesti Muszaki Egyetem, Department of Polymer Engineering	1	551	1075	1075	1075	0.5125581395348837	budapesti-muszaki-egyetem-department-of-polymer-engineering
+Budapesti Muszaki es Gazdasagtudomanyi Egyetem/Budapest University of Technology and Economics	5	70	0	1104	1104	0.06340579710144928	budapesti-muszaki-es-gazdasagtudomanyi-egyetem-budapest-university-of-technology-and-economics
+Bulgarian-American Center	1	0	240	240	240	0.0	bulgarian-american-center
+Bulletin of anesthesia history	1	549	0	0	552	0.9945652173913043	bulletin-of-anesthesia-history
+Bureau of Scientific Publications of the Foundation for Education, Science and Technology	1	16	308	308	308	0.05194805194805195	bureau-of-scientific-publications-of-the-foundation-for-education-science-and-technology
+Buro van die Woordeboek van die Afrikaanse Taal	1	0	1113	1113	1113	0.0	buro-van-die-woordeboek-van-die-afrikaanse-taal
+Bursa Ilahiyat Foundation	1	0	0	155	155	0.0	bursa-ilahiyat-foundation
+Business Center for Academic Societies Japan/Nihon Gakkai Jimu Senta	5	2509	0	6209	8808	0.2848546775658492	business-center-for-academic-societies-japan-nihon-gakkai-jimu-senta
+Business Perspectives	3	0	0	377	377	0.0	business-perspectives
+C I C Edizioni International srl	1	161	163	163	163	0.9877300613496932	c-i-c-edizioni-international-srl
+C M B Association	1	0	0	39	39	0.0	c-m-b-association
+C M L Publications	2	441	0	0	441	1.0	c-m-l-publications
+C.V. Mosby Company	2	15678	0	7375	15778	0.993662061097731	c-v-mosby-company
+c/o David William Foster, Arizona State University	1	2190	2190	2190	2190	1.0	c-o-david-william-foster-arizona-state-university
+CA and CC Press AB	1	0	0	1	1	0.0	ca-and-cc-press-ab
+CAB International	1	40	0	740	740	0.05405405405405406	cab-international
+CABI Publishing	2	1080	0	0	1113	0.9703504043126685	cabi-publishing
+Cactus & Succulent Society of America	1	150	0	157	157	0.9554140127388535	cactus-succulent-society-of-america
+CAIRN Belgique	1	65	0	2689	2689	0.024172554853105245	cairn-belgique
+Cairo University	2	755	763	763	763	0.9895150720838795	cairo-university
+Caister Academic Press	1	0	217	217	217	0.0	caister-academic-press
+Calabar School of Philosophy (CSP)	1	0	0	43	43	0.0	calabar-school-of-philosophy-csp
+California Agricultural Experiment Station	1	61	843	843	843	0.07236061684460261	california-agricultural-experiment-station
+California Folklore Society	1	4080	0	4080	4080	1.0	california-folklore-society
+California State University	1	0	0	344	344	0.0	california-state-university
+Calvin College Press	1	630	0	0	646	0.9752321981424149	calvin-college-press
+Cambridge International Science Publishing	1	0	0	0	102	0.0	cambridge-international-science-publishing
+Cambridge University Press	357	965635	1148	1114395	1137914	0.8486010366336999	cambridge-university-press
+Camel Publishing House	1	1	0	119	119	0.008403361344537815	camel-publishing-house
+Canadian Anaesthetists Society	1	3383	0	0	3383	1.0	canadian-anaesthetists-society
+Canadian Association of Medical Radiation Technologists	1	261	0	0	261	1.0	canadian-association-of-medical-radiation-technologists
+Canadian Association of Slavists	1	630	0	0	1867	0.337439742903053	canadian-association-of-slavists
+Canadian Center of Science and Education	7	31	0	1525	13251	0.002339446079541167	canadian-center-of-science-and-education
+Canadian Evaluation Society	1	0	0	42	42	0.0	canadian-evaluation-society
+Canadian Geriatrics Society	1	3	0	151	151	0.019867549668874173	canadian-geriatrics-society
+Canadian Institute for Studies in Publishing Press	1	0	0	852	852	0.0	canadian-institute-for-studies-in-publishing-press
+Canadian Institute of Forestry/Institut Forestier du Canada	1	22	0	9954	9954	0.0022101667671287923	canadian-institute-of-forestry-institut-forestier-du-canada
+Canadian Institute of Geomatics	1	15	0	350	350	0.04285714285714286	canadian-institute-of-geomatics
+Canadian Institute of International Affairs	1	6536	0	10385	10385	0.6293692826191623	canadian-institute-of-international-affairs
+Canadian Institute of Metallurgy	1	138	0	0	160	0.8625	canadian-institute-of-metallurgy
+Canadian Institute of Mining	1	2894	0	2899	2899	0.9982752673335633	canadian-institute-of-mining
+Canadian Mathematical Society	2	122	0	9916	9916	0.012303348124243647	canadian-mathematical-society
+Canadian Medical Association/Association Medical Canadienne	5	10851	989	12164	12164	0.8920585333771786	canadian-medical-association-association-medical-canadienne
+Canadian Pharmacists Association	1	702	0	1548	1548	0.45348837209302323	canadian-pharmacists-association
+Canadian Psychological Association	2	3833	0	2144	4028	0.9515888778550149	canadian-psychological-association
+Canadian Public Health Association	1	0	0	411	411	0.0	canadian-public-health-association
+Canadian Science and Technology Historical Society	1	352	0	0	566	0.6219081272084805	canadian-science-and-technology-historical-society
+Canadian Society for Pharmaceutical Sciences	1	0	444	444	444	0.0	canadian-society-for-pharmaceutical-sciences
+Canadian Society for the Study of Education	1	1482	0	1495	1495	0.991304347826087	canadian-society-for-the-study-of-education
+Canadian Society of Agricultural Engineering	1	23	0	57	57	0.40350877192982454	canadian-society-of-agricultural-engineering
+Canadian Society of Hospital Pharmacists	1	0	0	823	823	0.0	canadian-society-of-hospital-pharmacists
+Canadian Society of Petrolem Geologists	1	427	0	464	464	0.9202586206896551	canadian-society-of-petrolem-geologists
+Canadian Urological Association	1	319	0	2771	2771	0.11512089498376038	canadian-urological-association
+Canadian Veterinary Medical Association	1	870	0	5027	5027	0.17306544658842252	canadian-veterinary-medical-association
+Cancer Information Group	4	1427	0	0	1427	1.0	cancer-information-group
+Cancer Intellilgence	1	127	397	397	397	0.3198992443324937	cancer-intellilgence
+Cancer Media Group	1	0	0	1	1	0.0	cancer-media-group
+Cannadian Academic Accounting Association	1	57	0	0	64	0.890625	cannadian-academic-accounting-association
+Cape Shoulder Institute	1	138	241	241	241	0.5726141078838174	cape-shoulder-institute
+Carden Jennings Publishing	1	0	0	0	175	0.0	carden-jennings-publishing
+Cardiofront, Inc.	1	0	0	119	119	0.0	cardiofront-inc
+Cardiological Society of India	1	1871	0	1922	1922	0.9734651404786681	cardiological-society-of-india
+Cardiovascular Research Center, Faghihi Hospital	1	0	0	0	8	0.0	cardiovascular-research-center-faghihi-hospital
+Carl Hanser Verlag	8	1783	0	6578	6825	0.26124542124542127	carl-hanser-verlag
+Carl Heymanns Verlag KG	2	1026	0	47	1121	0.9152542372881356	carl-heymanns-verlag-kg
+Carlsberg Laboratory	1	469	0	0	469	1.0	carlsberg-laboratory
+Carnegie Endowment for International Peace	1	2215	0	2215	2215	1.0	carnegie-endowment-for-international-peace
+Carnegie Mellon University	1	293	0	581	581	0.504302925989673	carnegie-mellon-university
+Carnegie Museum of Natural History	1	157	0	164	164	0.9573170731707317	carnegie-museum-of-natural-history
+Casa de Velazquez	1	1	0	773	773	0.00129366106080207	casa-de-velazquez
+Casa Editrice Dott. Antonio Milani	1	1	0	232	232	0.004310344827586207	casa-editrice-dott-antonio-milani
+Casa Editrice II Ponte	1	815	0	0	815	1.0	casa-editrice-ii-ponte
+Casalini Libri Digital Division	1	10	0	1059	1059	0.009442870632672332	casalini-libri-digital-division
+CATENA Verlag	1	373	0	0	373	1.0	catena-verlag
+Catholic University of America Press	1	87	0	5460	5460	0.015934065934065933	catholic-university-of-america-press
+CEBRAP - Centro Brasileiro de Analise e Planejamento	1	1	433	433	433	0.0023094688221709007	cebrap-centro-brasileiro-de-analise-e-planejamento
+Cedec	1	0	886	886	886	0.0	cedec
+Celal Bayar Universitesi	1	0	843	0	843	0.0	celal-bayar-universitesi
+Cell Stress Society International	1	820	0	1367	1367	0.5998536942209217	cell-stress-society-international
+Celsius Publishing House	1	0	0	112	112	0.0	celsius-publishing-house
+Centauro SRL	1	158	0	0	161	0.9813664596273292	centauro-srl
+Centaurus-Verlagsgesellschaft	1	0	0	0	115	0.0	centaurus-verlagsgesellschaft
+Center for Academic Publications Japan	1	3222	0	3256	3256	0.9895577395577395	center-for-academic-publications-japan
+Center for Black Music Research	1	369	0	372	372	0.9919354838709677	center-for-black-music-research
+Center for Constitutional Studies	1	0	0	40	40	0.0	center-for-constitutional-studies
+Center for Foreign Policy and Peace Research, Ihsan Dogramaci Peace Foundation	1	0	0	55	55	0.0	center-for-foreign-policy-and-peace-research-ihsan-dogramaci-peace-foundation
+Center for International Studies (CIS-IUL) of the Lisbon University Institute (ISCTE)	1	0	184	184	184	0.0	center-for-international-studies-cis-iul-of-the-lisbon-university-institute-iscte
+Center for the Study of Film and History	1	24	0	498	498	0.04819277108433735	center-for-the-study-of-film-and-history
+Center for the Study of Venoms and Venomous Animals (CEVAP)	1	0	0	0	255	0.0	center-for-the-study-of-venoms-and-venomous-animals-cevap
+Center for Western Studies	1	301	305	305	305	0.9868852459016394	center-for-western-studies
+Center of Alcohol Studies, Rutgers, The State University of New Jersey	1	388	0	1215	1215	0.31934156378600825	center-of-alcohol-studies-rutgers-the-state-university-of-new-jersey
+Centers for Disease Control and Prevention (CDC)	4	2288	10789	10789	10789	0.21206784688108257	centers-for-disease-control-and-prevention-cdc
+Centers for Medicare & Medicaid Services' Office of Research, Development & Information	1	1	0	0	103	0.009708737864077669	centers-for-medicare-medicaid-services-office-of-research-development-information
+Central African Journal of Medicine Co.	1	0	0	0	233	0.0	central-african-journal-of-medicine-co
+Central Fisheries Research Institute	1	30	0	792	792	0.03787878787878788	central-fisheries-research-institute
+Central Missouri State University	1	63	0	70	70	0.9	central-missouri-state-university
+Centre d'etudes mongoles et siberiennes	1	0	0	133	133	0.0	centre-detudes-mongoles-et-siberiennes
+Centre d'etudes Superieures de Civilisation Medievale	1	7	0	938	938	0.007462686567164179	centre-detudes-superieures-de-civilisation-medievale
+Centre de recherche de l'Universite de Paris 8	1	5	0	718	718	0.006963788300835654	centre-de-recherche-de-luniversite-de-paris-8
+Centre de Visio per Computador	1	1	61	61	61	0.01639344262295082	centre-de-visio-per-computador
+Centre for Addiction and Mental Health	1	0	457	457	457	0.0	centre-for-addiction-and-mental-health
+Centre For Agricultural Publishing And Documentation	1	598	0	0	598	1.0	centre-for-agricultural-publishing-and-documentation
+Centre for Education in the Built Environment (CEBE)	1	0	0	0	115	0.0	centre-for-education-in-the-built-environment-cebe
+Centre for Latin American Research and Documentation/Centro de Estudios y Documentación Latinoamericanos (CEDLA)	1	0	234	234	234	0.0	centre-for-latin-american-research-and-documentation-centro-de-estudios-y-documentacion-latinoamericanos-cedla
+Centre for Overseas Pest Research	1	2421	0	0	2427	0.9975278121137207	centre-for-overseas-pest-research
+Centre national d'information demographique	1	0	0	0	233	0.0	centre-national-dinformation-demographique
+Centre Nationale de la Recherche Scientifique	1	2	897	897	897	0.002229654403567447	centre-nationale-de-la-recherche-scientifique
+Centre of Sociological Research	2	0	340	522	522	0.0	centre-of-sociological-research
+Centre Regional de Documentation Pedagogique de Picardie	1	0	0	496	496	0.0	centre-regional-de-documentation-pedagogique-de-picardie
+Centro de Ciencias Aplicadas y Desarrollo Tecnologico, Universidad Nacional Autonoma de Mexico	1	325	330	330	330	0.9848484848484849	centro-de-ciencias-aplicadas-y-desarrollo-tecnologico-universidad-nacional-autonoma-de-mexico
+Centro de Estudios de Derecho Penal de la Universidad de Talca	1	0	160	160	160	0.0	centro-de-estudios-de-derecho-penal-de-la-universidad-de-talca
+Centro de Estudios del Desarrollo de la Universidad Central de Venezuela	1	0	0	150	150	0.0	centro-de-estudios-del-desarrollo-de-la-universidad-central-de-venezuela
+Centro de Estudios Politicos y Constitucionales	4	0	0	195	195	0.0	centro-de-estudios-politicos-y-constitucionales
+Centro de Estudos de Opiniao Publica, Universidade Estadual de Campinas	1	0	258	258	258	0.0	centro-de-estudos-de-opiniao-publica-universidade-estadual-de-campinas
+Centro de Estudos do Crescimento e do Desenvolvimento do Ser Humano	1	0	785	785	785	0.0	centro-de-estudos-do-crescimento-e-do-desenvolvimento-do-ser-humano
+Centro de Estudos Educacao e Sociedade - CEDES	1	0	377	377	377	0.0	centro-de-estudos-educacao-e-sociedade-cedes
+Centro de Estudos em Recursos Naturais Renovaveis	1	1	80	80	80	0.0125	centro-de-estudos-em-recursos-naturais-renovaveis
+Centro de estudos sociais	1	0	385	385	385	0.0	centro-de-estudos-sociais
+Centro de Formacao(CENFOR)	1	316	0	0	316	1.0	centro-de-formacao-cenfor
+Centro de Informacion Tecnologica	1	3	387	387	387	0.007751937984496124	centro-de-informacion-tecnologica
+Centro de Investigacion en Computacion (CIC) del Instituto Politecnico Nacional (IPN)	1	1	0	244	244	0.004098360655737705	centro-de-investigacion-en-computacion-cic-del-instituto-politecnico-nacional-ipn
+Centro de Investigaciones Sociologicas	1	1794	0	1975	1975	0.9083544303797468	centro-de-investigaciones-sociologicas
+Centro de Investigaciones y Publicaciones Farmaceuticas	1	0	406	406	406	0.0	centro-de-investigaciones-y-publicaciones-farmaceuticas
+Centro de Pesquisas Florestais	1	0	925	925	925	0.0	centro-de-pesquisas-florestais
+Centro de Referencia em Informacao Ambiental	2	29	3505	3505	3505	0.008273894436519259	centro-de-referencia-em-informacao-ambiental
+Centro em Rede de Investigacao em Antropologia - CRIA	1	1	285	285	285	0.0035087719298245615	centro-em-rede-de-investigacao-em-antropologia-cria
+Centro Hospitalarios San Juan De Dios	1	3	320	320	320	0.009375	centro-hospitalarios-san-juan-de-dios
+Centro Interamericano de Investigaciones Psicologicas y Ciencias Afines	1	0	85	85	85	0.0	centro-interamericano-de-investigaciones-psicologicas-y-ciencias-afines
+Centro Internacional de Agricultura Tropical (CIAT)	1	0	0	169	169	0.0	centro-internacional-de-agricultura-tropical-ciat
+Centro Nacional de Informacion y Documentacion Cientifica	1	1	530	530	530	0.0018867924528301887	centro-nacional-de-informacion-y-documentacion-cientifica
+Centro Nacional de Investigaciones Metalurgicas	1	0	1212	1212	1212	0.0	centro-nacional-de-investigaciones-metalurgicas
+Ceramic Society of Japan/Nippon Seramikkusu Kyokai	1	6770	0	6888	6888	0.9828687572590011	ceramic-society-of-japan-nippon-seramikkusu-kyokai
+Ceramurgia S.p.A.	1	378	0	0	378	1.0	ceramurgia-s-p-a
+Cerrahpasa Tip Fakultesi Psikiyatri Klinigi	1	0	0	50	50	0.0	cerrahpasa-tip-fakultesi-psikiyatri-klinigi
+Ceska Akademie Verlag	1	0	0	27	27	0.0	ceska-akademie-verlag
+Ceska Akademie Zemedelskych Ved	6	21	782	782	782	0.026854219948849106	ceska-akademie-zemedelskych-ved
+Ceska Botanicka Spolecnost/Czech Botanical Society	1	0	0	4	4	0.0	ceska-botanicka-spolecnost-czech-botanical-society
+Ceska Geologicka Sluzba/Czech Geological Survey	1	13	446	446	446	0.02914798206278027	ceska-geologicka-sluzba-czech-geological-survey
+Cevre Koruma ve Arastirma Vakfi	1	4	0	331	331	0.012084592145015106	cevre-koruma-ve-arastirma-vakfi
+Changchun Institute of Applied Chemistry	1	0	0	917	917	0.0	changchun-institute-of-applied-chemistry
+Changchun Institute of Optics, Fine Mechanics and Physics, Chinese Academy of Sciences	1	0	0	193	193	0.0	changchun-institute-of-optics-fine-mechanics-and-physics-chinese-academy-of-sciences
+Charles University	3	0	140	186	186	0.0	charles-university
+Chelonian Research Foundation	1	471	0	473	473	0.9957716701902748	chelonian-research-foundation
+Chem-Bio Informatics Society	1	0	126	126	126	0.0	chem-bio-informatics-society
+Chemic Publishing Co.	1	24	0	6265	6265	0.003830806065442937	chemic-publishing-co
+Chemical Engineering Department, Bangladesh University of Engineering and Technology	1	9	65	65	65	0.13846153846153847	chemical-engineering-department-bangladesh-university-of-engineering-and-technology
+Chemical Industry Press	1	2087	0	2110	2110	0.9890995260663508	chemical-industry-press
+Chemical Society	9	16254	0	322	19275	0.8432684824902724	chemical-society
+Chemical Society of Ethiopia	1	73	747	747	747	0.09772423025435073	chemical-society-of-ethiopia
+Chemical Society of Japan/Nippon Kagakukai	3	62605	0	62585	71636	0.8739321011781785	chemical-society-of-japan-nippon-kagakukai
+Chemistry Central	3	1669	1732	1732	1732	0.9636258660508084	chemistry-central
+Chengdu Institute of Biology, Chinese Academy of Sciences	1	0	0	140	140	0.0	chengdu-institute-of-biology-chinese-academy-of-sciences
+Chevron Publishing Corporation	1	0	0	198	198	0.0	chevron-publishing-corporation
+Chiang Mai University	1	1	0	133	133	0.007518796992481203	chiang-mai-university
+Chiba-Shi Research Society Of Physiological Anthropology	1	10	0	0	464	0.021551724137931036	chiba-shi-research-society-of-physiological-anthropology
+China Academy of Traditional Chinese Medicine	1	1792	0	1808	1808	0.9911504424778761	china-academy-of-traditional-chinese-medicine
+China Aerospace Science and Industry Corporation	1	0	0	749	749	0.0	china-aerospace-science-and-industry-corporation
+China Coal Society	1	588	0	0	588	1.0	china-coal-society
+China Institute of Communication	1	1139	0	1173	1173	0.9710144927536232	china-institute-of-communication
+China Machine Press	2	756	0	11773	11773	0.06421472861632549	china-machine-press
+China Meteorological Press	1	206	0	206	206	1.0	china-meteorological-press
+China National Rice Research Institute	1	459	0	467	467	0.9828693790149893	china-national-rice-research-institute
+China Ocean Press	1	1456	0	1459	1459	0.997943797121316	china-ocean-press
+China Ordnance Society	1	232	0	235	235	0.9872340425531915	china-ordnance-society
+China Pharmaceutical University	1	44	0	431	431	0.10208816705336426	china-pharmaceutical-university
+China University of Geosciences	1	151	0	0	151	1.0	china-university-of-geosciences
+China University of Geosciences (Beijing) and Peking University	1	526	543	543	543	0.9686924493554327	china-university-of-geosciences-beijing-and-peking-university
+Chinese Academy of Agricultural Sciences	1	277	0	277	277	1.0	chinese-academy-of-agricultural-sciences
+Chinese Academy of Fishery Sciences	1	0	0	447	447	0.0	chinese-academy-of-fishery-sciences
+Chinese Academy of Sciences	6	437	445	6507	6507	0.06715844475180575	chinese-academy-of-sciences
+Chinese Anticancer Association	1	0	0	63	63	0.0	chinese-anticancer-association
+Chinese Ceramic Society	1	98	0	101	101	0.9702970297029703	chinese-ceramic-society
+Chinese Institute of Automation Engineers (CIAE)	1	0	203	203	203	0.0	chinese-institute-of-automation-engineers-ciae
+Chinese Institute of Chemical Engineers	1	160	0	0	160	1.0	chinese-institute-of-chemical-engineers
+Chinese Institute of Environmental Engineering (CIEnvE)	1	66	0	68	68	0.9705882352941176	chinese-institute-of-environmental-engineering-cienve
+Chinese Institute of Industrial Engineers	1	864	0	0	864	1.0	chinese-institute-of-industrial-engineers
+Chinese Physical Society	1	0	0	1546	1546	0.0	chinese-physical-society
+Chinese Physiology Society/Chung-kuo Sheng Li Hsueh Hui	1	6	0	380	380	0.015789473684210527	chinese-physiology-society-chung-kuo-sheng-li-hsueh-hui
+Chinese Society of Nonferrous Metal	1	1955	0	2009	2009	0.9731209556993529	chinese-society-of-nonferrous-metal
+Chinese Society of Particuology; The Institute of Process Engineering	1	359	0	0	359	1.0	chinese-society-of-particuology-the-institute-of-process-engineering
+Chinese Society of Pavement Engineering	1	80	0	88	88	0.9090909090909091	chinese-society-of-pavement-engineering
+Chongqing University of Posts and Telecommunications	1	78	0	82	82	0.9512195121951219	chongqing-university-of-posts-and-telecommunications
+Chroma Inc.	1	2	0	0	72	0.027777777777777776	chroma-inc
+Chulalongkorn University	2	4	379	614	614	0.006514657980456026	chulalongkorn-university
+Churchill	1	85	0	0	85	1.0	churchill
+CIC Edizioni Internazionali	7	0	237	610	610	0.0	cic-edizioni-internazionali
+Cidade-Editora Cientifica	1	0	0	0	402	0.0	cidade-editora-cientifica
+CIG Media Group, LP	1	112	0	0	113	0.9911504424778761	cig-media-group-lp
+CILIP Information Literacy Group	1	0	277	277	277	0.0	cilip-information-literacy-group
+City University of New York	1	1259	0	1275	1275	0.9874509803921568	city-university-of-new-york
+Ciudad Universitaria	1	103	104	104	104	0.9903846153846154	ciudad-universitaria
+Clarendon Press	1	0	0	0	5	0.0	clarendon-press
+Clarke Historical Library	2	1499	0	1553	1553	0.9652285898261429	clarke-historical-library
+Classical Association of South Africa	1	1	0	55	55	0.01818181818181818	classical-association-of-south-africa
+Classical Association of the Middle West and South	1	327	0	392	392	0.8341836734693877	classical-association-of-the-middle-west-and-south
+Cleveland Clinic Educational Foundation	1	123	6282	6282	6282	0.019579751671442217	cleveland-clinic-educational-foundation
+Clinical Laboratory Publications	1	9	0	1259	1259	0.007148530579825258	clinical-laboratory-publications
+Clinics Cardive Publishing Ltd.	1	1	0	516	516	0.001937984496124031	clinics-cardive-publishing-ltd
+Cluj University Press	2	0	0	41	41	0.0	cluj-university-press
+Co-Action Publishing	3	1155	96	709	1660	0.6957831325301205	co-action-publishing
+Coastal Education & Research Foundation, Inc.	1	3402	0	3547	3547	0.9591203834226106	coastal-education-research-foundation-inc
+Cogent OA	4	437	578	703	703	0.6216216216216216	cogent-oa
+Cogitatio Press	3	0	420	420	420	0.0	cogitatio-press
+Cognizant Communication Corporation	10	2246	0	3147	3286	0.6835057821059038	cognizant-communication-corporation
+Cold Spring Harbor Laboratory Press	8	20252	0	32782	32782	0.6177780489292904	cold-spring-harbor-laboratory-press
+Colegio Brasileiro de Ciencias do Esporte (CBCE)	1	181	442	442	442	0.4095022624434389	colegio-brasileiro-de-ciencias-do-esporte-cbce
+Colegio Brasileiro de Cirurgia Digestiva	1	2	128	128	128	0.015625	colegio-brasileiro-de-cirurgia-digestiva
+Colegio Brasileiro de Cirurgioes	1	0	0	45	45	0.0	colegio-brasileiro-de-cirurgioes
+Colegio Brasileiro de Patologia Animal	1	7	1660	1660	1660	0.004216867469879518	colegio-brasileiro-de-patologia-animal
+Colegio Brasileiro de Radiologia	1	5	1547	1547	1547	0.003232062055591467	colegio-brasileiro-de-radiologia
+Colegio Brasileiro de Reproducao Animal	1	0	72	72	72	0.0	colegio-brasileiro-de-reproducao-animal
+Colegio de Mexico, A.C.	1	0	0	1	1	0.0	colegio-de-mexico-a-c
+Colegio Nacional de Opticos-Optometristas de Espana	1	323	330	330	330	0.9787878787878788	colegio-nacional-de-opticos-optometristas-de-espana
+College Of Anaesthesiologists Of Sri Lanka	1	0	231	231	231	0.0	college-of-anaesthesiologists-of-sri-lanka
+College of Chiropractors	1	179	0	0	179	1.0	college-of-chiropractors
+College of Humanities, University of Arizona	1	30	0	47	47	0.6382978723404256	college-of-humanities-university-of-arizona
+College of Statistical and Actuarial Sciences, University of Punjab	1	0	358	358	358	0.0	college-of-statistical-and-actuarial-sciences-university-of-punjab
+College Publications	1	20	0	526	526	0.03802281368821293	college-publications
+College Reading Association	1	611	0	0	611	1.0	college-reading-association
+Colleges of Education	1	996	0	0	998	0.9979959919839679	colleges-of-education
+Collegium Basilea	1	0	0	122	122	0.0	collegium-basilea
+Colombian Corporation of Agricultural Research (Corpoica)	1	0	0	330	330	0.0	colombian-corporation-of-agricultural-research-corpoica
+Columbia Law Review Association	1	13173	0	13173	13173	1.0	columbia-law-review-association
+Commission des Annales de l'Ecole Nationale des Ponts et Chaussees	1	50	0	0	50	1.0	commission-des-annales-de-lecole-nationale-des-ponts-et-chaussees
+Committee on Canadian Labour History	1	2824	0	0	2824	1.0	committee-on-canadian-labour-history
+Committee on Data for Science and Technology (CODATA) International Council for Science (ICSU)	1	1	589	589	589	0.001697792869269949	committee-on-data-for-science-and-technology-codata-international-council-for-science-icsu
+Committee on Physical Culture and Sports of the Council of Ministers of the USSR	1	0	0	5	5	0.0	committee-on-physical-culture-and-sports-of-the-council-of-ministers-of-the-ussr
+Common Ground Research Networks	51	0	0	8516	10647	0.0	common-ground-research-networks
+Commonwealth Forestry Association	1	707	0	797	797	0.8870765370138017	commonwealth-forestry-association
+Commonwealth Fund	1	0	0	2	2	0.0	commonwealth-fund
+Community Development Society	1	828	0	0	829	0.9987937273823885	community-development-society
+Company of Biologists Ltd	1	845	914	914	914	0.9245076586433261	company-of-biologists-ltd
+Comparative Cognition Society	1	48	0	92	92	0.5217391304347826	comparative-cognition-society
+Compuscript Ltd.	1	138	171	171	171	0.8070175438596491	compuscript-ltd
+Computational Mechanics Publications	1	54	0	0	54	1.0	computational-mechanics-publications
+ComSIS Consortium	1	9	568	568	568	0.01584507042253521	comsis-consortium
+Conseil Superieur de la Peche	1	157	0	0	676	0.23224852071005916	conseil-superieur-de-la-peche
+Consejo Superior De Investigaciones Cientificas	19	13	12382	12904	12904	0.0010074395536267824	consejo-superior-de-investigaciones-cientificas
+Conservatoire et Jardin Botaniques de la Ville de Geneve	1	282	0	306	306	0.9215686274509803	conservatoire-et-jardin-botaniques-de-la-ville-de-geneve
+Consolidated Medieval Studies Research Group	1	0	0	30	30	0.0	consolidated-medieval-studies-research-group
+Consortium of Multiple Sclerosis Centers (CMSC)	1	1	0	571	571	0.0017513134851138354	consortium-of-multiple-sclerosis-centers-cmsc
+Constantine the Philosopher University in Nitra	1	0	0	47	47	0.0	constantine-the-philosopher-university-in-nitra
+Consultants Bureau	10	73297	0	9118	73438	0.9980800130722515	consultants-bureau
+Contemporary China Centre	2	3194	0	2495	3375	0.9463703703703704	contemporary-china-centre
+Copernicus	21	4022	29966	27368	31503	0.12767038059867314	copernicus
+Core Medical Pub	1	17	129	129	129	0.13178294573643412	core-medical-pub
+Cornell University Press	2	17505	0	17635	17635	0.9926282960022682	cornell-university-press
+Cornetis	1	0	0	48	48	0.0	cornetis
+Corporacion Universitaria Lasallista	1	0	0	122	122	0.0	corporacion-universitaria-lasallista
+Corporacion Universitaria Republicana	1	0	0	9	9	0.0	corporacion-universitaria-republicana
+Corporation for National Research Initiatives	1	1	1034	1034	1034	9.671179883945841e-4	corporation-for-national-research-initiatives
+Cortez and Moraes	1	1	1128	1128	1128	8.865248226950354e-4	cortez-and-moraes
+Corvinus University of Budapest	1	0	0	62	62	0.0	corvinus-university-of-budapest
+Council for Research in Music Education, School of Music, University of Illinois	1	97	0	123	123	0.7886178861788617	council-for-research-in-music-education-school-of-music-university-of-illinois
+Council for Social Development	1	434	0	0	681	0.6372980910425844	council-for-social-development
+Council for the Development of Economic and Social Research in Africa	1	0	0	278	278	0.0	council-for-the-development-of-economic-and-social-research-in-africa
+Council of Forensic Medicine of Turkey	1	1	0	0	159	0.006289308176100629	council-of-forensic-medicine-of-turkey
+Council on Foreign Relations, Inc.	1	13913	0	13913	13913	1.0	council-on-foreign-relations-inc
+Council on Social Work Education	1	827	0	0	830	0.9963855421686747	council-on-social-work-education
+Creative Age Publications Inc.	1	576	0	0	576	1.0	creative-age-publications-inc
+Croatian Academy of Sciences and Arts	2	0	70	70	70	0.0	croatian-academy-of-sciences-and-arts
+Croatian Association of Researchers in Children's Literature	1	0	0	113	113	0.0	croatian-association-of-researchers-in-childrens-literature
+Croatian Conservation Institute	1	0	0	52	52	0.0	croatian-conservation-institute
+Croatian Dairy Union	1	25	47	47	47	0.5319148936170213	croatian-dairy-union
+Croatian Ethnological Society	1	1	27	27	27	0.037037037037037035	croatian-ethnological-society
+Crop Science Society of America	3	1035	332	21601	21601	0.04791444840516643	crop-science-society-of-america
+Crop Science Society of Japan	1	0	0	6175	6175	0.0	crop-science-society-of-japan
+CSIC Consejo Superior de Investigaciones Cientificas	10	31	5309	6176	6176	0.005019430051813471	csic-consejo-superior-de-investigaciones-cientificas
+CSIRO	31	32653	55	63602	85262	0.38297248481152213	csiro
+Cukurova Univ Tip Fakultesi Psikiyatri Anabilim Dali	1	231	394	394	394	0.5862944162436549	cukurova-univ-tip-fakultesi-psikiyatri-anabilim-dali
+Cumhuriyet University	2	15	192	573	573	0.02617801047120419	cumhuriyet-university
+Current Controlled Trials Ltd.	1	137	0	0	137	1.0	current-controlled-trials-ltd
+Current Medicine Group	5	2220	0	2268	2268	0.9788359788359788	current-medicine-group
+Current Patents, Ltd.	1	541	0	0	860	0.6290697674418605	current-patents-ltd
+Curtin University of Technology	1	564	0	0	564	1.0	curtin-university-of-technology
+Cushman Fondation for Foraminiferal Research	1	1163	0	1557	1557	0.7469492614001284	cushman-fondation-for-foraminiferal-research
+Czech Academy of Agricultural Sciences	5	41	589	589	589	0.06960950764006792	czech-academy-of-agricultural-sciences
+Czech Academy of Sciences	1	2	0	185	185	0.010810810810810811	czech-academy-of-sciences
+Czech Geological Society	1	132	249	249	249	0.5301204819277109	czech-geological-society
+Czech Geological Survey	1	0	0	102	102	0.0	czech-geological-survey
+Czech Medical Association J.E. Purkyne	2	1	0	488	488	0.0020491803278688526	czech-medical-association-j-e-purkyne
+Czech Phycological Society	1	0	209	209	209	0.0	czech-phycological-society
+Czech Technical University	1	0	337	337	337	0.0	czech-technical-university
+Czestochowa University of Technology	1	0	0	81	81	0.0	czestochowa-university-of-technology
+DAAAM International Vienna	1	177	0	325	325	0.5446153846153846	daaam-international-vienna
+Daehan sin'gyeong oe'gwa haghoe	1	0	0	180	180	0.0	daehan-singyeong-oegwa-haghoe
+Dalloz Editions	1	45	0	1224	1224	0.03676470588235294	dalloz-editions
+Danish Psychological Publishers	1	873	0	0	1074	0.8128491620111732	danish-psychological-publishers
+Data Trace Publishing Co.	2	147	0	220	367	0.40054495912806537	data-trace-publishing-co
+David and Lucile Packard Foundation	1	408	0	582	582	0.7010309278350515	david-and-lucile-packard-foundation
+De Boccard Edition Diffusion	2	18	0	0	4702	0.0038281582305401958	de-boccard-edition-diffusion
+De Boeck & Larcier	14	107	0	6378	6616	0.016172914147521162	de-boeck-larcier
+De Boeck Universite	2	6	0	446	682	0.008797653958944282	de-boeck-universite
+De la Salle University	3	0	0	130	1128	0.0	de-la-salle-university
+Deepak Ranjan Jena	1	0	0	46	46	0.0	deepak-ranjan-jena
+Defence Scientific Information & Documentation Centre	2	0	0	2569	2569	0.0	defence-scientific-information-documentation-centre
+Delachaux et Niestle	1	2	0	398	398	0.005025125628140704	delachaux-et-niestle
+Demetrios A. Spandidos Ed. & Pub.	3	17783	0	24809	24809	0.7167963239147084	demetrios-a-spandidos-ed-pub
+Democratic Nursing Organisation of South Africa	1	1	0	1277	1277	7.830853563038371e-4	democratic-nursing-organisation-of-south-africa
+Dental Investigations Society	1	18	0	406	406	0.04433497536945813	dental-investigations-society
+Dental Press	1	0	0	0	4	0.0	dental-press
+Dental Press Editora Ltda	2	12	879	879	879	0.013651877133105802	dental-press-editora-ltda
+Dep. de Geographie de l'Universite Laval	1	2436	0	3867	3867	0.6299456943366951	dep-de-geographie-de-luniversite-laval
+Departamento de Diseno Visual, Universidad de Caldas	1	0	0	11	11	0.0	departamento-de-diseno-visual-universidad-de-caldas
+Departamento de Historia, Universidade Estadual de Ponta Grossa	1	0	133	133	133	0.0	departamento-de-historia-universidade-estadual-de-ponta-grossa
+Departamento de Matematicas, Universidad Catolica del Norte	1	0	374	374	374	0.0	departamento-de-matematicas-universidad-catolica-del-norte
+Departamento de Psicologia, Universidade de Brasilia	1	2	860	860	860	0.002325581395348837	departamento-de-psicologia-universidade-de-brasilia
+Department of Applied Research, Institute of Mathematics of National Academy of Science of Ukraine	1	41	1220	1220	1220	0.03360655737704918	department-of-applied-research-institute-of-mathematics-of-national-academy-of-science-of-ukraine
+Department of Business Communication, Aarhus School of Business	1	0	0	651	651	0.0	department-of-business-communication-aarhus-school-of-business
+Department of Computer Science, University of Auckland	1	0	0	2	2	0.0	department-of-computer-science-university-of-auckland
+Department of English, Universidad de La Rioja	1	0	0	0	18	0.0	department-of-english-universidad-de-la-rioja
+Department of Logic, University of Lodz	1	0	5	5	5	0.0	department-of-logic-university-of-lodz
+Department of Mathematics, Hokkaido University	1	50	0	1321	1321	0.03785011355034065	department-of-mathematics-hokkaido-university
+Department of Pharmacy, Stamford University Bangladesh	1	0	0	0	92	0.0	department-of-pharmacy-stamford-university-bangladesh
+Department of Veterans Affairs	1	743	1609	1609	1609	0.4617775015537601	department-of-veterans-affairs
+Depaul University, Department of Philosophy	1	0	0	199	199	0.0	depaul-university-department-of-philosophy
+Dept. of Agricultural Economics, University of Illinois at Urbana-Champaign	1	317	0	0	317	1.0	dept-of-agricultural-economics-university-of-illinois-at-urbana-champaign
+Der Gesellschaft	1	496	0	0	496	1.0	der-gesellschaft
+Deri ve Zuhrevi Hastaliklar Dernegi	1	220	413	413	413	0.5326876513317191	deri-ve-zuhrevi-hastaliklar-dernegi
+Derman Medical Publishing	1	0	1214	1214	1214	0.0	derman-medical-publishing
+Desalination Publications	1	8444	0	8555	8555	0.9870251315020456	desalination-publications
+DEStech Publications	1	0	0	0	73	0.0	destech-publications
+Deutscher Kunstverlag	1	2107	0	2107	2107	1.0	deutscher-kunstverlag
+Deutscher Verlag fur Grundstoffindustrie	1	8978	0	0	9044	0.9927023440955329	deutscher-verlag-fur-grundstoffindustrie
+di xue qian yuan bian ji bu	1	10	439	439	439	0.022779043280182234	di-xue-qian-yuan-bian-ji-bu
+Diabetes Technology Society	1	1948	0	2037	2037	0.9563082965144821	diabetes-technology-society
+Dianzi Celiang yu Yiqi Xuebao	1	1	0	0	787	0.0012706480304955528	dianzi-celiang-yu-yiqi-xuebao
+Didier-Erudition	1	0	0	621	621	0.0	didier-erudition
+Dietitians of Canada	1	60	0	617	617	0.09724473257698542	dietitians-of-canada
+Dietrich Steinkopff Verlag	20	52993	0	47925	54828	0.9665316991318305	dietrich-steinkopff-verlag
+Diffusion de Boccard	1	6	0	0	11290	5.314437555358724e-4	diffusion-de-boccard
+Digestive Diseases Foundation	1	0	0	333	333	0.0	digestive-diseases-foundation
+Dinastiia	1	0	0	84	84	0.0	dinastiia
+Diponegoro University	2	77	378	671	671	0.11475409836065574	diponegoro-university
+Dissolution Technologies, Inc.	1	4	0	533	533	0.0075046904315197	dissolution-technologies-inc
+Division of Food Science, Centre for Agrotechnology and Veterinary Sciences, Polish Academy of Sciences	1	96	102	102	102	0.9411764705882353	division-of-food-science-centre-for-agrotechnology-and-veterinary-sciences-polish-academy-of-sciences
+Division on Career Development and Transition (DCDT)	1	10	0	0	10	1.0	division-on-career-development-and-transition-dcdt
+Dm Planejamento E Propoganda	1	119	0	130	130	0.9153846153846154	dm-planejamento-e-propoganda
+Documenta Chemica Yugoslavia	1	1071	2131	2131	2131	0.5025809479117785	documenta-chemica-yugoslavia
+Documentation Francaise	1	0	0	731	731	0.0	documentation-francaise
+Down Syndrome Educational Trust	1	0	0	0	212	0.0	down-syndrome-educational-trust
+Doxa	1	62	0	0	62	1.0	doxa
+Dr. Becker & Partner AG-Verlag fuer Ganzheits Medizin	1	22	0	1030	1030	0.021359223300970873	dr-becker-partner-ag-verlag-fuer-ganzheits-medizin
+Dropsie College for Hebrew and Cognate Learning	1	4743	0	4743	4743	1.0	dropsie-college-for-hebrew-and-cognate-learning
+Drug Information Association	1	368	0	0	368	1.0	drug-information-association
+Drug Intelligence and Clinical Pharmacy, Inc.	1	57	0	0	317	0.17981072555205047	drug-intelligence-and-clinical-pharmacy-inc
+Drustvo Geneticara Srbije	1	13	778	778	778	0.016709511568123392	drustvo-geneticara-srbije
+Drustvo lekara Vojvodine	1	709	1400	1400	1400	0.5064285714285715	drustvo-lekara-vojvodine
+Drustvo Medicinskin Biochemicara Jugoslavije/Yugoslav Society of Medical Biochemists	1	22	0	0	252	0.0873015873015873	drustvo-medicinskin-biochemicara-jugoslavije-yugoslav-society-of-medical-biochemists
+Drustvo Psihologija Srbije	1	3	418	418	418	0.007177033492822967	drustvo-psihologija-srbije
+Drustvo za Opazovanje in Proucevanje Ptic Slovenije/Bird Watching and Bird Study Association of Slovenia	1	23	0	68	68	0.3382352941176471	drustvo-za-opazovanje-in-proucevanje-ptic-slovenije-bird-watching-and-bird-study-association-of-slovenia
+"Drutvo ljekara SR Bosne i Hercegovine : ""Avicena"" d.o.o"	1	16	0	0	670	0.023880597014925373	drutvo-ljekara-sr-bosne-i-hercegovine-avicena-d-o-o
+Duke University Press	39	70319	4265	93358	93358	0.7532187921763533	duke-university-press
+Duncker und Humbolt GmbH	2	3	0	235	235	0.01276595744680851	duncker-und-humbolt-gmbh
+Dunod	2	404	0	0	8828	0.04576347983688265	dunod
+Duquesne University Press	1	0	0	125	125	0.0	duquesne-university-press
+Dustri-Verlag Dr. Karl Feistle	12	247	0	8855	10272	0.02404595015576324	dustri-verlag-dr-karl-feistle
+Dynamic Publishers, Inc.	1	0	0	0	2	0.0	dynamic-publishers-inc
+Dynasty Publishing House	3	0	0	224	224	0.0	dynasty-publishing-house
+E P P Publications	1	0	0	0	360	0.0	e-p-p-publications
+E. & F.N. Spon	2	1483	0	0	1484	0.9993261455525606	e-f-n-spon
+E. Leroux	1	8	0	0	2529	0.0031633056544088573	e-leroux
+E. Schweizerbartsche Verlagsbuchhandlung	13	4781	0	6750	7823	0.6111466189441391	e-schweizerbartsche-verlagsbuchhandlung
+Eagle Hill Foundation	1	174	0	187	187	0.93048128342246	eagle-hill-foundation
+Earthquake Engineering Research Institute	1	2141	0	2183	2183	0.9807604214383875	earthquake-engineering-research-institute
+East African Public Health Association	1	0	0	0	154	0.0	east-african-public-health-association
+Eastern Group Psychotherapy Society	1	913	0	0	982	0.929735234215886	eastern-group-psychotherapy-society
+Eastern University, PhD in Organizational Leadership	1	0	149	149	149	0.0	eastern-university-phd-in-organizational-leadership
+Eaton Publishing Co.	1	78	0	2108	2108	0.03700189753320683	eaton-publishing-co
+ECN - Editora Cientifica Nacional Ltda.	1	1	430	430	430	0.002325581395348837	ecn-editora-cientifica-nacional-ltda
+Eco-Vector LLC	1	0	0	157	157	0.0	eco-vector-llc
+Ecole Francaise d'Extreme-Orient	1	0	0	0	184	0.0	ecole-francaise-dextreme-orient
+Ecole Nationale du Genie Rural des Eaux et des Forets	1	0	0	6335	6335	0.0	ecole-nationale-du-genie-rural-des-eaux-et-des-forets
+Ecole Nationale Veterinaire De Toulouse	1	0	0	1	1	0.0	ecole-nationale-veterinaire-de-toulouse
+Ecole Pratique des Hautes Etudes	1	2	0	0	694	0.002881844380403458	ecole-pratique-des-hautes-etudes
+Ecological Society of China	1	0	0	4298	4298	0.0	ecological-society-of-china
+Ecology and Civil Engineering Society	1	0	0	355	355	0.0	ecology-and-civil-engineering-society
+Ecomed Verlagsgesellschaft AG & Co.	1	2243	0	0	2243	1.0	ecomed-verlagsgesellschaft-ag-co
+eContent Management Pty Ltd	1	208	0	0	262	0.7938931297709924	econtent-management-pty-ltd
+EDAM-Education Consultancy Limited	1	207	0	402	402	0.5149253731343284	edam-education-consultancy-limited
+Ediciones Doyma, S.L.	1	151	0	152	152	0.993421052631579	ediciones-doyma-s-l
+Ediciones Ergon S.A.	1	389	766	766	766	0.5078328981723238	ediciones-ergon-s-a
+Ediciones Medicina y Cultura	1	0	0	113	113	0.0	ediciones-medicina-y-cultura
+Ediciones Paidos Iberoamerica	1	14	0	14	14	1.0	ediciones-paidos-iberoamerica
+Ediciones Universidad de Salamanca	1	0	0	30	30	0.0	ediciones-universidad-de-salamanca
+Edinburgh University Global Health Society	1	1	0	218	218	0.0045871559633027525	edinburgh-university-global-health-society
+Edinburgh University Press	22	3297	0	17341	17702	0.18625014122698	edinburgh-university-press
+Edisud Publishers	1	3	885	885	885	0.003389830508474576	edisud-publishers
+Editio Cantor Verlag	1	1943	0	0	1944	0.9994855967078189	editio-cantor-verlag
+Editions Antipodes	1	0	0	545	545	0.0	editions-antipodes
+Editions Belin	4	8	0	5791	5791	0.0013814539803142809	editions-belin
+Editions Biere	1	0	0	2690	2690	0.0	editions-biere
+Editions de Boccard	1	0	0	0	590	0.0	editions-de-boccard
+Editions de I'Ecole des Hautes Etudes en Sciences Sociales	6	20	0	6674	6674	0.0029967036260113876	editions-de-iecole-des-hautes-etudes-en-sciences-sociales
+Editions de l' Atelier	1	2785	0	3387	3387	0.822261588426336	editions-de-l-atelier
+Editions de Sante	1	1093	0	1107	1107	0.987353206865402	editions-de-sante
+Editions du Seuil	1	9	0	850	850	0.010588235294117647	editions-du-seuil
+Editions E D K	1	79	0	8033	8033	0.009834432964023403	editions-e-d-k
+Editions Eres	7	50	0	4892	4892	0.010220768601798855	editions-eres
+Editions ESKA	5	21	0	1732	1863	0.011272141706924315	editions-eska
+Editions Flammarion	1	0	583	583	583	0.0	editions-flammarion
+Editions l'Harmattan	2	1	0	329	342	0.0029239766081871343	editions-lharmattan
+Editions La Decouverte	2	26	0	1592	1592	0.016331658291457288	editions-la-decouverte
+Editions La Simarre	1	0	0	0	172	0.0	editions-la-simarre
+Editions Medecine et Hygiene	3	9	0	1744	1744	0.005160550458715597	editions-medecine-et-hygiene
+Editions NecPlus	3	316	0	4353	4353	0.07259361359981621	editions-necplus
+Editions Odile Jacob	1	0	0	1081	1081	0.0	editions-odile-jacob
+Editions Ophrys	1	3386	0	3860	3860	0.8772020725388601	editions-ophrys
+Editions Scientifiques E Story Scientia	1	1	0	1231	1231	8.123476848090983e-4	editions-scientifiques-e-story-scientia
+Editions Sedes	1	3	0	0	1305	0.0022988505747126436	editions-sedes
+Editions Technip	2	18	1146	1146	2343	0.0076824583866837385	editions-technip
+Editora Champagnat	1	0	164	164	164	0.0	editora-champagnat
+Editora do Centro Universitario Sao Camilo	1	1	0	151	151	0.006622516556291391	editora-do-centro-universitario-sao-camilo
+Editora Universidade de Brasilia	1	0	758	758	758	0.0	editora-universidade-de-brasilia
+Editorial Ciencias Medicas	1	0	0	411	411	0.0	editorial-ciencias-medicas
+Editorial Committee of the Journal of Roman Archaeology	1	2377	0	2472	2472	0.9615695792880259	editorial-committee-of-the-journal-of-roman-archaeology
+Editorial Complutense	1	0	0	87	87	0.0	editorial-complutense
+Editorial de la Universidad de Costa Rica	1	1	1740	1740	1740	5.747126436781609e-4	editorial-de-la-universidad-de-costa-rica
+Editorial Dept. of Agricultural Sciences in China	1	1184	0	0	1184	1.0	editorial-dept-of-agricultural-sciences-in-china
+Editorial Dips Rocas	1	1254	0	1265	1265	0.991304347826087	editorial-dips-rocas
+Editorial Garsi	1	818	0	826	826	0.9903147699757869	editorial-garsi
+Editorial Laser S.A de C.V.	1	0	0	228	228	0.0	editorial-laser-s-a-de-c-v
+Editorial Office of Chemical Engineering	1	0	0	0	1422	0.0	editorial-office-of-chemical-engineering
+Editorial Office of Chinese Journal of Plant Ecology	1	1	0	1409	1409	7.097232079489e-4	editorial-office-of-chinese-journal-of-plant-ecology
+Editorial Office of Gut and Liver	1	9	973	973	973	0.009249743062692703	editorial-office-of-gut-and-liver
+Editorial Office of Journal of Chinese Pharmaceutical Sciences	1	2	0	585	585	0.003418803418803419	editorial-office-of-journal-of-chinese-pharmaceutical-sciences
+Editorial Universidad de Granada	1	1	145	145	145	0.006896551724137931	editorial-universidad-de-granada
+Editorial Universidad de Talca	4	5	1532	1532	1532	0.0032637075718015664	editorial-universidad-de-talca
+Editrice Compositori srl	2	3428	0	0	3428	1.0	editrice-compositori-srl
+Editura Economica	1	20	37	37	37	0.5405405405405406	editura-economica
+Editura Medicala	1	19	0	206	206	0.09223300970873786	editura-medicala
+Editura Universitatea Alexendru Ion Cuza	1	128	0	247	247	0.5182186234817814	editura-universitatea-alexendru-ion-cuza
+Edizioni Comune di Milano Amici del Museo del Risorgimento	1	0	0	0	10	0.0	edizioni-comune-di-milano-amici-del-museo-del-risorgimento
+Edizioni ETS	1	0	306	306	306	0.0	edizioni-ets
+Edouard Privat Editeur	1	0	0	0	5	0.0	edouard-privat-editeur
+EDP Sciences	46	11666	3135	62635	93861	0.12429017376759251	edp-sciences
+EDRA S.p.A	1	677	0	744	744	0.9099462365591398	edra-s-p-a
+Educational Publishing Foundation	1	685	0	0	756	0.906084656084656	educational-publishing-foundation
+EduRad Publishing	1	5	570	570	570	0.008771929824561403	edurad-publishing
+Edward Elgar Publishing Ltd.	3	9	0	554	554	0.016245487364620937	edward-elgar-publishing-ltd
+EEG and Clinical Neuroscience Society	1	2	0	0	9	0.2222222222222222	eeg-and-clinical-neuroscience-society
+Eesti Metsamajanduse ja Looduskaitse Instituut	1	18	40	40	40	0.45	eesti-metsamajanduse-ja-looduskaitse-instituut
+Egea-Bocconi University Press	1	463	0	0	464	0.9978448275862069	egea-bocconi-university-press
+Egypt Exploration Society	1	3611	0	3611	3611	1.0	egypt-exploration-society
+Egyptian Petroleum Research Institute	1	358	0	362	362	0.988950276243094	egyptian-petroleum-research-institute
+Egyptian Society of Anaesthesiologists	1	455	471	471	471	0.9660297239915074	egyptian-society-of-anaesthesiologists
+Egyptian Society of Cardiology	1	394	401	401	401	0.9825436408977556	egyptian-society-of-cardiology
+Egyptian Society of Chest Diseases and Tuberculosis	1	713	0	733	733	0.9727148703956344	egyptian-society-of-chest-diseases-and-tuberculosis
+Egyptian Society of Ear, Nose, Throat and Allied Sciences	1	286	303	303	303	0.9438943894389439	egyptian-society-of-ear-nose-throat-and-allied-sciences
+Eizo Joho Media Gakkai	1	3	0	5117	5117	5.86281024037522e-4	eizo-joho-media-gakkai
+Ejmanager LLC	1	5	0	226	226	0.022123893805309734	ejmanager-llc
+Ekip Limited	1	0	0	23	23	0.0	ekip-limited
+Ekonomski Fakultet	1	2	371	371	371	0.005390835579514825	ekonomski-fakultet
+El Colegio de Mexico	1	0	0	7	7	0.0	el-colegio-de-mexico
+El Jardin	1	0	367	367	367	0.0	el-jardin
+Electrochemical Science Group, University of Belgrade	1	0	938	938	938	0.0	electrochemical-science-group-university-of-belgrade
+Electrochemical Society of Japan	1	1352	0	2386	2386	0.5666387259010897	electrochemical-society-of-japan
+Electrochemical Society, Inc.	5	54884	0	51622	55948	0.9809823407449775	electrochemical-society-inc
+Electromagnetics Academy	5	113	6871	8167	8167	0.013836169952246846	electromagnetics-academy
+Electronics and Telecommunications Research Institute	1	10	2209	2209	2209	0.004526935264825713	electronics-and-telecommunications-research-institute
+Element d.o.o.	3	15	0	2698	2698	0.005559673832468495	element-d-o-o
+eLife Sciences Publications	1	29	3618	3618	3618	0.008015478164731896	elife-sciences-publications
+Elsevier	3410	13115639	210333	12308330	13528561	0.9694777589427287	elsevier
+Emakeele Selts	1	0	80	80	80	0.0	emakeele-selts
+Emanuel University Press	1	0	7	7	7	0.0	emanuel-university-press
+EManuscript Services	2	545	0	910	910	0.5989010989010989	emanuscript-services
+Embry-Riddle Aeronautical University	1	0	0	57	57	0.0	embry-riddle-aeronautical-university
+Emerald	398	191393	0	244475	268170	0.71370026475743	emerald
+Emergency Medicine Association of Turkey	1	0	0	191	191	0.0	emergency-medicine-association-of-turkey
+Emerging Health Threats Forum	1	61	263	263	263	0.23193916349809887	emerging-health-threats-forum
+EMH Swiss Medical Publishers Ltd	1	41	1113	1113	1113	0.036837376460017966	emh-swiss-medical-publishers-ltd
+Empresa Basileira de Pesquisa Agropecuaria	1	36	3901	3901	3901	0.009228402973596514	empresa-basileira-de-pesquisa-agropecuaria
+EMUNI Press	2	11	103	103	103	0.10679611650485436	emuni-press
+Endocrine Society	2	2915	0	40	2925	0.9965811965811966	endocrine-society
+Endocrinology Research Centre (Moscow)	1	0	713	713	713	0.0	endocrinology-research-centre-moscow
+Engg Journals Publications	1	0	0	0	188	0.0	engg-journals-publications
+Engineering and Technology Publishing	1	10	0	789	789	0.012674271229404309	engineering-and-technology-publishing
+Engineering Institute of Canada	1	636	0	0	637	0.9984301412872841	engineering-institute-of-canada
+English Linguistic Society of Japan	1	0	0	0	616	0.0	english-linguistic-society-of-japan
+Entomological Society of America	2	23282	0	23517	23517	0.9900072288131989	entomological-society-of-america
+Entomological Society of Canada	2	199	0	0	410	0.4853658536585366	entomological-society-of-canada
+Entomological Society of Southern Africa/Entologiese Vereniging van Suidelike Afrika	1	574	0	608	608	0.944078947368421	entomological-society-of-southern-africa-entologiese-vereniging-van-suidelike-afrika
+Entomological Society of Turkey	1	1	0	129	129	0.007751937984496124	entomological-society-of-turkey
+Entomological Society of Washington	1	586	0	604	604	0.9701986754966887	entomological-society-of-washington
+Envirnomental Philosophy, Inc.	1	0	0	1808	1808	0.0	envirnomental-philosophy-inc
+Enviro Research Publishers	1	1	133	133	133	0.007518796992481203	enviro-research-publishers
+Environmental and Engineering Geophysical Society (EEGS)	1	319	0	564	564	0.5656028368794326	environmental-and-engineering-geophysical-society-eegs
+Epidemiology Program Office	1	0	0	22	22	0.0	epidemiology-program-office
+Equine Veterinary Journal Ltd.	1	4949	0	0	4949	1.0	equine-veterinary-journal-ltd
+Equinox Publishing Ltd	13	432	0	3852	3946	0.10947795235681702	equinox-publishing-ltd
+Erasmus Publishing B.V.	1	0	0	0	215	0.0	erasmus-publishing-b-v
+Eres Publishers	2	16	0	1868	1868	0.008565310492505354	eres-publishers
+Ernst Reinhardt Verlag	1	0	0	179	179	0.0	ernst-reinhardt-verlag
+Erudit Publishers	1	79	221	221	221	0.3574660633484163	erudit-publishers
+eScholarship University of California	1	0	24	24	24	0.0	escholarship-university-of-california
+Escola Brasileira de Administracao Publica da Fundacao Getulio Vargas	1	4	739	739	739	0.005412719891745603	escola-brasileira-de-administracao-publica-da-fundacao-getulio-vargas
+Escola de minas	1	0	0	907	907	0.0	escola-de-minas
+Escola Nacional de Saude Publica	1	26	5884	5884	5884	0.004418762746430999	escola-nacional-de-saude-publica
+Escola Paulista de Enfermagem, Universidade Federal de Sao Paulo	1	0	742	742	742	0.0	escola-paulista-de-enfermagem-universidade-federal-de-sao-paulo
+Escola Superior de Agricultura Luiz de Queiroz	1	5	91	91	91	0.054945054945054944	escola-superior-de-agricultura-luiz-de-queiroz
+ESCOM Science Publishers	1	332	0	0	332	1.0	escom-science-publishers
+Escuela Universitaria de Turismo, Universidad de Murcia	1	0	75	75	75	0.0	escuela-universitaria-de-turismo-universidad-de-murcia
+Esmon Publicidad S.A.	1	0	0	136	136	0.0	esmon-publicidad-s-a
+Essential Oil Resource Consultants	1	564	0	0	564	1.0	essential-oil-resource-consultants
+Estonian Academy of Sciences	1	147	203	203	203	0.7241379310344828	estonian-academy-of-sciences
+Estonian Academy Publishers	7	853	1205	1053	1533	0.5564253098499674	estonian-academy-publishers
+Estonian Association for Applied Linguistics	2	1	353	353	353	0.0028328611898017	estonian-association-for-applied-linguistics
+Estonian Naturalist's Society	1	30	62	62	62	0.4838709677419355	estonian-naturalists-society
+Estuarine Research Federation	1	1975	0	0	1975	1.0	estuarine-research-federation
+EtH Zurich	1	2	879	879	879	0.0022753128555176336	eth-zurich
+Ethiopian Pharmaceutical Association	1	0	0	0	129	0.0	ethiopian-pharmaceutical-association
+Ethiopian Public Health Association	1	0	0	379	379	0.0	ethiopian-public-health-association
+Etudes Theologiques et Religieuses	1	2	0	441	441	0.0045351473922902496	etudes-theologiques-et-religieuses
+Eui-Hak Publishing and Printing Co.	1	275	0	651	651	0.42242703533026116	eui-hak-publishing-and-printing-co
+Eular Publishers	1	482	0	0	482	1.0	eular-publishers
+Eurographics Association at Graz University of Technology	1	25	0	25	25	1.0	eurographics-association-at-graz-university-of-technology
+Europa Ed	1	7	0	2385	2385	0.0029350104821802936	europa-ed
+Europe's Journal of Psychology	1	2	587	587	587	0.0034071550255536627	europes-journal-of-psychology
+European Academy of HIV/AIDS and Infectious Diseases	1	0	108	108	108	0.0	european-academy-of-hiv-aids-and-infectious-diseases
+European Academy of Management and Business Economics	1	38	39	39	39	0.9743589743589743	european-academy-of-management-and-business-economics
+European Alliance for Innovation	1	0	10	10	10	0.0	european-alliance-for-innovation
+European Association for Aquatic Mammals	1	281	0	754	754	0.3726790450928382	european-association-for-aquatic-mammals
+European Association for Potato Research	1	490	0	0	490	1.0	european-association-for-potato-research
+European Association of Geochemistry	1	0	0	13	13	0.0	european-association-of-geochemistry
+European Association of Geoscientists and Engineers	1	383	0	1122	1122	0.3413547237076649	european-association-of-geoscientists-and-engineers
+European Association of Hospital Pharmacists (EAHP)	1	688	0	3338	3338	0.2061114439784302	european-association-of-hospital-pharmacists-eahp
+European Association of Science Editors	1	0	0	1	1	0.0	european-association-of-science-editors
+European Bioethical Research	1	251	0	0	266	0.943609022556391	european-bioethical-research
+European Centre for Disease Prevention and Control (ECDC)	1	2	919	919	919	0.002176278563656148	european-centre-for-disease-prevention-and-control-ecdc
+European Centre for Population Studies	1	362	0	0	363	0.9972451790633609	european-centre-for-population-studies
+European Dialysis and Transplant Nurses Association	1	462	0	0	462	1.0	european-dialysis-and-transplant-nurses-association
+European Journal for the Practitioner	1	58	0	0	678	0.0855457227138643	european-journal-for-the-practitioner
+European Journals Inc.	1	0	0	0	4	0.0	european-journals-inc
+European Mathematical Society Publishing House	12	3016	0	9643	9643	0.3127657368038992	european-mathematical-society-publishing-house
+European Polymer Federation	1	959	1435	1435	1435	0.6682926829268293	european-polymer-federation
+European Respiratory Society	5	11745	1283	19928	19945	0.5888693908247681	european-respiratory-society
+European Society for Research on the Education of Adults	1	0	106	106	106	0.0	european-society-for-research-on-the-education-of-adults
+Evereth Publishing Sp. z o.o.	1	0	0	152	152	0.0	evereth-publishing-sp-z-o-o
+Excerpta Medica	5	2215	0	0	2294	0.9655623365300785	excerpta-medica
+Expansion Scientifique Francaise	1	638	0	0	638	1.0	expansion-scientifique-francaise
+F. Steiner Verlag	1	1093	0	0	1096	0.9972627737226277	f-steiner-verlag
+F.J.E. Woodbridge : W.T. Bush	1	8385	0	12380	12380	0.6773021001615509	f-j-e-woodbridge-w-t-bush
+F1000 Research Ltd.	1	17	2927	2927	2927	0.0058079945336522035	f1000-research-ltd
+Fabrizio Serra Editore	1	1276	0	1276	1276	1.0	fabrizio-serra-editore
+Faculdade de Economia, Administracao e Contabilidade de Ribeirao Preto da Universidade de Sao Paulo	1	0	286	286	286	0.0	faculdade-de-economia-administracao-e-contabilidade-de-ribeirao-preto-da-universidade-de-sao-paulo
+Faculdade de Medicina : Hospital Sao Lucas da PUCRS	1	0	193	193	193	0.0	faculdade-de-medicina-hospital-sao-lucas-da-pucrs
+Faculdade de Medicina da Universidade de Sao Paulo	1	15	1074	1074	1074	0.013966480446927373	faculdade-de-medicina-da-universidade-de-sao-paulo
+Facultad de Artes, Universidad de Chile	1	0	841	841	841	0.0	facultad-de-artes-universidad-de-chile
+Facultad de Ciencias Politicas y Sociales, UNAM	1	187	189	189	189	0.9894179894179894	facultad-de-ciencias-politicas-y-sociales-unam
+Facultad de Comunicaciones de la Pontificia Universidad Catolica de Chile	1	0	0	71	71	0.0	facultad-de-comunicaciones-de-la-pontificia-universidad-catolica-de-chile
+Facultad de Derecho, Universidad Catolica de Chile	1	0	495	495	495	0.0	facultad-de-derecho-universidad-catolica-de-chile
+Facultad de Enfermeria de la Universidad de Antioquia	1	0	0	85	85	0.0	facultad-de-enfermeria-de-la-universidad-de-antioquia
+Facultad de Medicina Veterinaria, Universidad Nacional Mayor de San Marcos	1	0	862	862	862	0.0	facultad-de-medicina-veterinaria-universidad-nacional-mayor-de-san-marcos
+Facultad Latinoamericana de Ciencias Sociales Sede Mexico	1	0	112	112	112	0.0	facultad-latinoamericana-de-ciencias-sociales-sede-mexico
+Faculty of 1000 Ltd	1	33	0	241	241	0.13692946058091288	faculty-of-1000-ltd
+Faculty of Arts, Department of Philosophy Novi Sad	1	0	0	97	97	0.0	faculty-of-arts-department-of-philosophy-novi-sad
+Faculty of Biotechnology and Food Sciences, Slovak University of Agriculture	1	16	0	424	424	0.03773584905660377	faculty-of-biotechnology-and-food-sciences-slovak-university-of-agriculture
+Faculty of Economics and Management CULS Prague	1	0	55	55	55	0.0	faculty-of-economics-and-management-culs-prague
+Faculty of Education, Eskisehir Osmangazi University	1	0	58	58	58	0.0	faculty-of-education-eskisehir-osmangazi-university
+Faculty of Electrical Engineering Banja Luka	1	0	51	51	51	0.0	faculty-of-electrical-engineering-banja-luka
+Faculty of Engineering Universitas Indonesia	1	0	379	379	379	0.0	faculty-of-engineering-universitas-indonesia
+Faculty of Family Planning and Reproductive Health Care	1	1991	0	2270	2270	0.8770925110132158	faculty-of-family-planning-and-reproductive-health-care
+Faculty of General Dental Practitioners	2	763	0	293	980	0.7785714285714286	faculty-of-general-dental-practitioners
+Faculty of Mechanical Engineering, Belgrade University	1	2	163	163	163	0.012269938650306749	faculty-of-mechanical-engineering-belgrade-university
+Faculty of Medicine Universitas Indonesia	1	0	1097	1097	1097	0.0	faculty-of-medicine-universitas-indonesia
+Faculty of Psychology, Lomonosov Moscow State University	1	1	359	359	359	0.002785515320334262	faculty-of-psychology-lomonosov-moscow-state-university
+Faculty of Science and Technology, Universiti Kebangsaan Malaysia	1	0	0	207	207	0.0	faculty-of-science-and-technology-universiti-kebangsaan-malaysia
+Faculty of Social Sciences, Charles University	1	11	31	31	31	0.3548387096774194	faculty-of-social-sciences-charles-university
+Fakulteta za Organizacijske Vede, Univerza v Mariboru	1	77	0	144	144	0.5347222222222222	fakulteta-za-organizacijske-vede-univerza-v-mariboru
+Families International, Inc.	1	181	0	1276	1276	0.14184952978056425	families-international-inc
+Faraday Division of the Chemical Society	2	14287	0	0	17401	0.8210447675420953	faraday-division-of-the-chemical-society
+Farmaceutsko Drustvo Srbije	1	0	61	61	61	0.0	farmaceutsko-drustvo-srbije
+FB and Media Group of Estonian Literary Museum	1	0	0	479	479	0.0	fb-and-media-group-of-estonian-literary-museum
+FB Communication	6	0	0	0	277	0.0	fb-communication
+FEAPS (Confederacion Espanola de Organizaciones en favor de las Personas con Discapacidad Intelectual	1	0	0	29	29	0.0	feaps-confederacion-espanola-de-organizaciones-en-favor-de-las-personas-con-discapacidad-intelectual
+Federacao Latino-Americana de Sociedades do Sono	1	306	309	309	309	0.9902912621359223	federacao-latino-americana-de-sociedades-do-sono
+Federacion de Asociaciones de Ingenieros Industriales de Espana	1	1	0	110	110	0.00909090909090909	federacion-de-asociaciones-de-ingenieros-industriales-de-espana
+Federal Legal Publications, Inc.	1	124	0	0	330	0.37575757575757573	federal-legal-publications-inc
+Federal Research Center Computer Science and Control of the Russian Academy of Sciences	1	0	0	181	181	0.0	federal-research-center-computer-science-and-control-of-the-russian-academy-of-sciences
+Federal Reserve Bank of St. Louis	1	0	0	33	33	0.0	federal-reserve-bank-of-st-louis
+Federal Universidade of Santa Maria. Center of Ciencias Rurais	1	256	5710	5710	5710	0.04483362521891419	federal-universidade-of-santa-maria-center-of-ciencias-rurais
+Federal University of Bahia Human Resources Center	1	0	4	4	4	0.0	federal-university-of-bahia-human-resources-center
+Federal University of Piaui	1	0	90	90	90	0.0	federal-university-of-piaui
+Federation of American Societies for Experimental Biology	2	11700	0	11781	11781	0.9931245225362872	federation-of-american-societies-for-experimental-biology
+Federation of Obstetric & Gynaecological Societies of India	1	966	0	1001	1001	0.965034965034965	federation-of-obstetric-gynaecological-societies-of-india
+Federation of Societies for Coatings Technology	1	310	0	0	310	1.0	federation-of-societies-for-coatings-technology
+Feminist Studies, Inc.	1	1194	0	1229	1229	0.9715215622457283	feminist-studies-inc
+Ferd. Dummler	1	0	0	1899	1899	0.0	ferd-dummler
+Ferrata Storti Foundation	1	2663	3803	3803	3803	0.7002366552721535	ferrata-storti-foundation
+Field Museum	2	24	0	0	24	1.0	field-museum
+Field Naturalists Club of Victoria	1	0	0	0	4	0.0	field-naturalists-club-of-victoria
+Filozofski fakultet - Institut za istoriju umetnosti	1	2	156	156	156	0.01282051282051282	filozofski-fakultet-institut-za-istoriju-umetnosti
+Finnish Institute of Occupational Health	1	19	0	2675	2675	0.007102803738317757	finnish-institute-of-occupational-health
+Finnish Zoological and Botanical Publishing Board	2	961	0	969	969	0.9917440660474717	finnish-zoological-and-botanical-publishing-board
+Fischer	1	433	0	0	433	1.0	fischer
+Fischer Medical Publications	4	1800	0	0	1800	1.0	fischer-medical-publications
+Florida Entomologist Society	1	5799	5881	5881	5881	0.9860567930624043	florida-entomologist-society
+Florida State University	1	103	0	0	1271	0.08103855232100708	florida-state-university
+Fluminense Federal University	1	0	0	1253	1253	0.0	fluminense-federal-university
+Folklore of Ireland Society	1	1056	0	1056	1056	1.0	folklore-of-ireland-society
+Fondation Nationale de Gerontologie	1	3	0	0	864	0.003472222222222222	fondation-nationale-de-gerontologie
+Fondation universitaire	1	12	0	2791	2791	0.004299534217126478	fondation-universitaire
+Fondo de Cultura Economica	1	0	195	195	195	0.0	fondo-de-cultura-economica
+Food and Nutrition Press, Inc.	3	1745	0	0	1745	1.0	food-and-nutrition-press-inc
+Food Hygienic Society of Japan/Nihon Shokuhin Eisei Gakkai	1	3840	0	3881	3881	0.9894357124452461	food-hygienic-society-of-japan-nihon-shokuhin-eisei-gakkai
+Food Products Press	6	634	0	0	797	0.795483061480552	food-products-press
+Foreign Policy Research Center	1	5	11	11	11	0.45454545454545453	foreign-policy-research-center
+Forensic Science Society	2	4192	0	1674	4206	0.9966714217784118	forensic-science-society
+Forest Herbarium	1	0	0	22	22	0.0	forest-herbarium
+Forest Products Society	1	0	0	541	541	0.0	forest-products-society
+Forest Research and Management Institute	1	0	85	85	85	0.0	forest-research-and-management-institute
+Forestry Commission of the Hungarian Academy of Sciences	1	20	63	63	63	0.31746031746031744	forestry-commission-of-the-hungarian-academy-of-sciences
+Fort Orange Press	2	449	0	0	450	0.9977777777777778	fort-orange-press
+Forum For Medical Ethics Society	1	0	0	305	305	0.0	forum-for-medical-ethics-society
+Forum service editore	1	85	0	0	85	1.0	forum-service-editore
+Foundation for Enviromental Protection and Research	1	79	85	85	85	0.9294117647058824	foundation-for-enviromental-protection-and-research
+Foundation for Research in Modern History, Saint-Petersburg State University	1	0	0	8	8	0.0	foundation-for-research-in-modern-history-saint-petersburg-state-university
+Franco Angeli Edizioni	15	0	0	2041	2412	0.0	franco-angeli-edizioni
+Francophone Association of Accounting	1	49	0	599	599	0.08180300500834725	francophone-association-of-accounting
+Franz Steiner Verlag	1	1154	0	1154	1154	1.0	franz-steiner-verlag
+Freshwater Biological Association	1	1	0	183	183	0.00546448087431694	freshwater-biological-association
+Friends Science Publishers	1	2	345	345	345	0.005797101449275362	friends-science-publishers
+Frontiers in Bioscience	3	181	0	6433	6433	0.028136172858697343	frontiers-in-bioscience
+Frontiers Media S.A.	32	10407	62989	63994	64101	0.16235316141713857	frontiers-media-s-a
+Frontiers Research Foundation	2	23	264	435	435	0.052873563218390804	frontiers-research-foundation
+Frontline Medical Communications	1	2	0	316	316	0.006329113924050633	frontline-medical-communications
+Fuji Technology Press	4	0	0	6328	6328	0.0	fuji-technology-press
+Fukushima Society of Medical Science	1	0	0	255	255	0.0	fukushima-society-of-medical-science
+Fundacao APINCO de Ciencia e Technologia Avicolas	1	0	572	572	572	0.0	fundacao-apinco-de-ciencia-e-technologia-avicolas
+Fundacao Carlos Chagas	1	0	652	652	652	0.0	fundacao-carlos-chagas
+Fundacao Cesgranrio	2	1	455	455	455	0.002197802197802198	fundacao-cesgranrio
+Fundacao de Pesquisas Cientificas de Ribeirao Preto	1	198	6944	6944	6944	0.028513824884792628	fundacao-de-pesquisas-cientificas-de-ribeirao-preto
+Fundacao do Instituto de Biociencias	1	4	113	113	113	0.035398230088495575	fundacao-do-instituto-de-biociencias
+Fundacao Editora UNESP	2	6	0	0	488	0.012295081967213115	fundacao-editora-unesp
+Fundacao Escola de Comercio Alvares Penteado (FECAP)	1	0	265	265	265	0.0	fundacao-escola-de-comercio-alvares-penteado-fecap
+Fundacao Getulio Vargas, Escola de Administracao de Empresas de Sao Paulo	1	2	58	58	58	0.034482758620689655	fundacao-getulio-vargas-escola-de-administracao-de-empresas-de-sao-paulo
+Fundacao O Boticario de Protecao a Natureza	1	109	0	0	236	0.461864406779661	fundacao-o-boticario-de-protecao-a-natureza
+Fundacao Oswaldo Cruz	2	46	9457	9457	9457	0.004864121814528921	fundacao-oswaldo-cruz
+Fundacao Sistema Estadual de Analise de Dados	1	0	0	0	351	0.0	fundacao-sistema-estadual-de-analise-de-dados
+Fundacao Zoobotanica do Rio Grande	1	13	779	779	779	0.01668806161745828	fundacao-zoobotanica-do-rio-grande
+Fundacio per la Universitat Oberta de Catalunya	2	156	511	188	511	0.30528375733855184	fundacio-per-la-universitat-oberta-de-catalunya
+Fundacion Aigle	1	0	0	12	12	0.0	fundacion-aigle
+Fundacion Index	1	0	710	710	710	0.0	fundacion-index
+Fundacion Neumomadrid	1	165	0	165	165	1.0	fundacion-neumomadrid
+Fundacion Privada Educacion Medica	1	134	0	581	581	0.2306368330464716	fundacion-privada-educacion-medica
+Fundacja Polski Przeglad Chirurgiczny	1	523	996	996	996	0.5251004016064257	fundacja-polski-przeglad-chirurgiczny
+Funtai Funmatsu Yakin Kyokai	1	64	0	6698	6698	0.00955509107196178	funtai-funmatsu-yakin-kyokai
+Fushoku Boshoku Kyokai	1	0	0	1892	1892	0.0	fushoku-boshoku-kyokai
+Futura Publishing Company, Inc	3	197	0	0	197	1.0	futura-publishing-company-inc
+Future Drugs Ltd.	3	1785	0	0	2270	0.7863436123348018	future-drugs-ltd
+Future Medicine Ltd.	32	24210	0	20853	24912	0.971820809248555	future-medicine-ltd
+Futuribles International	1	0	0	613	613	0.0	futuribles-international
+G J D Tholen N V	1	3	0	430	430	0.0069767441860465115	g-j-d-tholen-n-v
+Gabonatermesztesi Kutato Kozhasznu Tarsasag/Cereal Research Non-Profit Company	1	282	0	1442	1442	0.1955617198335645	gabonatermesztesi-kutato-kozhasznu-tarsasag-cereal-research-non-profit-company
+Gadjah Mada University	3	0	61	321	321	0.0	gadjah-mada-university
+Gai-Kan Bianjibu	1	0	0	877	877	0.0	gai-kan-bianjibu
+Gakushin Company Ltd.	1	0	0	1175	1175	0.0	gakushin-company-ltd
+Galenos Yayincilik	7	866	1599	2516	2516	0.3441971383147854	galenos-yayincilik
+Gallaudet University Press	2	227	0	3191	3191	0.07113757442807897	gallaudet-university-press
+Gallimard	1	2	0	1131	1131	0.0017683465959328027	gallimard
+Ganglie Yanjiu Xuebao	1	1840	0	1862	1862	0.9881847475832438	ganglie-yanjiu-xuebao
+Gaodeng Jiaoyu Chubanshe	9	2779	0	233	2779	1.0	gaodeng-jiaoyu-chubanshe
+Gaurav Society of Agricultural Research Information Centre	1	1	0	392	392	0.002551020408163265	gaurav-society-of-agricultural-research-information-centre
+Gauthier-Villars	6	2134	0	132	2355	0.9061571125265393	gauthier-villars
+Gazi Universitesi	2	0	57	351	351	0.0	gazi-universitesi
+Gebr. Mann Verlag	1	410	0	0	410	1.0	gebr-mann-verlag
+Gebruder Borntraeger Verlagsbuchhandlung	5	2351	1057	3921	3921	0.5995919408314205	gebruder-borntraeger-verlagsbuchhandlung
+Gedung Pusat Pengkajian Islam dan Masyarakat (PPIM) UIN Jakarta	1	0	512	512	512	0.0	gedung-pusat-pengkajian-islam-dan-masyarakat-ppim-uin-jakarta
+Gemmological Association and Gem Testing Laboratory of Great Britain	1	1	0	701	701	0.0014265335235378032	gemmological-association-and-gem-testing-laboratory-of-great-britain
+Gemological Institute of America	1	35	0	1204	1204	0.029069767441860465	gemological-institute-of-america
+Generalitat de Catalunya	1	567	0	570	570	0.9947368421052631	generalitat-de-catalunya
+Genetics Society of America	2	7077	1489	7317	7317	0.96719967199672	genetics-society-of-america
+Genetics Society of Japan/Nihon Iden Gakkai	1	986	0	1155	1155	0.8536796536796537	genetics-society-of-japan-nihon-iden-gakkai
+Geofizicki Zavod	1	8	31	31	31	0.25806451612903225	geofizicki-zavod
+Geografski institut Antona Melika ZRC SAZU	1	15	0	77	77	0.19480519480519481	geografski-institut-antona-melika-zrc-sazu
+Geographical Society of Ireland	1	958	0	1029	1029	0.9310009718172984	geographical-society-of-ireland
+Geologica Belgica	1	0	24	24	24	0.0	geologica-belgica
+Geological Association of Canada	1	5	0	117	117	0.042735042735042736	geological-association-of-canada
+Geological Publishing House	1	4033	0	0	4199	0.9604667778042391	geological-publishing-house
+Geological Society	9	20124	0	22605	22605	0.8902455209024552	geological-society
+Geological Society of America	9	24415	0	33522	33801	0.7223159078133783	geological-society-of-america
+Geological Society of Australia	1	928	0	0	928	1.0	geological-society-of-australia
+Geological Society of China	1	32	0	32	32	1.0	geological-society-of-china
+Geological Society of Finland	1	0	12	12	12	0.0	geological-society-of-finland
+Geological Society of India	1	1432	0	1482	1482	0.9662618083670715	geological-society-of-india
+Geological Society of Japan	1	0	0	0	7684	0.0	geological-society-of-japan
+Geological Society of Korea	1	817	0	826	826	0.9891041162227603	geological-society-of-korea
+Geological Society of Poland	1	0	0	65	65	0.0	geological-society-of-poland
+Geologischen Gesellschaft	1	108	0	0	108	1.0	geologischen-gesellschaft
+Geologists' Association	1	6188	0	6267	6267	0.9873942875378969	geologists-association
+GEOMATE International Society	1	0	0	633	633	0.0	geomate-international-society
+Geometry & Topology Publications	1	337	0	1390	1390	0.24244604316546764	geometry-topology-publications
+George Washington University	1	299	0	960	960	0.31145833333333334	george-washington-university
+Georgia Entomological Society, Inc.	1	285	0	287	287	0.9930313588850174	georgia-entomological-society-inc
+Gerontological Society of America	3	17160	0	17736	23686	0.7244785949506037	gerontological-society-of-america
+Ghana Medical Association	1	50	0	278	278	0.17985611510791366	ghana-medical-association
+Gheorghe Zane Institute for Economic and Social Research, Romanian Academy, Iasi Branch	2	0	0	428	428	0.0	gheorghe-zane-institute-for-economic-and-social-research-romanian-academy-iasi-branch
+Giordano dell'Amore Foundation	1	10	0	10	10	1.0	giordano-dellamore-foundation
+Global Digital Central	1	0	202	202	202	0.0	global-digital-central
+Global Institute of Flexible Systems Management	1	153	0	153	153	1.0	global-institute-of-flexible-systems-management
+Global Research Online	1	0	0	0	2	0.0	global-research-online
+GMM	1	214	0	0	221	0.9683257918552036	gmm
+GMMA Department of Public health	1	85	547	547	547	0.15539305301645337	gmma-department-of-public-health
+Gobierno de Navarra	1	0	889	889	889	0.0	gobierno-de-navarra
+Gondolat Kiado	1	0	0	16	16	0.0	gondolat-kiado
+Good Health Trading Limited	1	39	0	0	101	0.38613861386138615	good-health-trading-limited
+Goteborg University	1	36	408	408	408	0.08823529411764706	goteborg-university
+Graduate School, Boston University	1	1598	0	1598	1598	1.0	graduate-school-boston-university
+Grafo edizioni	1	878	0	0	878	1.0	grafo-edizioni
+Graham & Trotman	1	101	0	0	101	1.0	graham-trotman
+Greatpoland Cancer Center and Polish Society of Radiation Oncology	1	78	0	0	78	1.0	greatpoland-cancer-center-and-polish-society-of-radiation-oncology
+Greenleaf Publishing	2	305	0	61	328	0.9298780487804879	greenleaf-publishing
+Greenwich Medical Media	2	39	0	0	46	0.8478260869565217	greenwich-medical-media
+Group Communication and Innovation Studies	1	138	0	0	138	1.0	group-communication-and-innovation-studies
+Groupe des Methodes Pluridisciplinaires Contribuant a l'Archeologie	1	0	0	327	327	0.0	groupe-des-methodes-pluridisciplinaires-contribuant-a-larcheologie
+Growing Science	4	32	577	827	827	0.03869407496977025	growing-science
+Grune & Stratton	1	1262	0	0	1262	1.0	grune-stratton
+Grune And Stratton	1	555	0	0	556	0.9982014388489209	grune-and-stratton
+Grupo Aula Medica S.A.	2	279	339	626	626	0.44568690095846647	grupo-aula-medica-s-a
+Grupo Comunicar, Colectivo Andaluz de Educacion en Medios de Comunicacion	1	319	521	521	521	0.6122840690978887	grupo-comunicar-colectivo-andaluz-de-educacion-en-medios-de-comunicacion
+Grupo de Estudos Estado e Sociedade, Universidade Federal do Parana	1	0	36	36	36	0.0	grupo-de-estudos-estado-e-sociedade-universidade-federal-do-parana
+Guilford Press	11	5068	0	7220	7798	0.6499102333931778	guilford-press
+Guizhou Key Laboratory of Agricultural Biotechnology	1	6	195	195	195	0.03076923076923077	guizhou-key-laboratory-of-agricultural-biotechnology
+Gulhane Military Academy	1	182	0	400	400	0.455	gulhane-military-academy
+Gustav Fischer Verlag	6	4674	0	0	4676	0.9995722840034217	gustav-fischer-verlag
+Gutersloher Verlagshaus Mohn	1	188	0	243	243	0.7736625514403292	gutersloher-verlagshaus-mohn
+H E C Press	1	378	0	391	391	0.9667519181585678	h-e-c-press
+HACCP Consulting	1	5	455	455	455	0.01098901098901099	haccp-consulting
+Hacettepe Universitesi	4	0	0	658	658	0.0	hacettepe-universitesi
+Haerbin Gongcheng Daxue/Harbin Engineering University	1	760	0	770	770	0.987012987012987	haerbin-gongcheng-daxue-harbin-engineering-university
+Hall Associates	1	215	0	0	215	1.0	hall-associates
+Hamad Medical Corporation, State of Qatar	1	2	48	48	48	0.041666666666666664	hamad-medical-corporation-state-of-qatar
+Hamburg University	1	0	0	56	56	0.0	hamburg-university
+Han-Gug Misaengmul Hag-hoe/The Microbiological Society of Korea	1	1217	0	1227	1227	0.9918500407497962	han-gug-misaengmul-hag-hoe-the-microbiological-society-of-korea
+Han'guk Mulli Hakhoe	1	3401	0	8305	8305	0.4095123419626731	hanguk-mulli-hakhoe
+Han'guk Pogon Sahoe Yon'guwon	1	0	0	0	486	0.0	hanguk-pogon-sahoe-yonguwon
+Hanguk Misaengmul Hakhoe	1	1	280	280	280	0.0035714285714285713	hanguk-misaengmul-hakhoe
+Hanguk Palpu Chongi Kisul Hyophoe	1	0	0	369	369	0.0	hanguk-palpu-chongi-kisul-hyophoe
+Hans Huber AG	5	3	0	0	1155	0.0025974025974025974	hans-huber-ag
+Hanser Publishers	2	2148	0	2332	3267	0.657483930211203	hanser-publishers
+Hanyang University	1	159	0	163	163	0.9754601226993865	hanyang-university
+HARD Pub. Co.	2	386	0	1013	1013	0.3810463968410661	hard-pub-co
+Harper and Row	2	913	0	0	914	0.9989059080962801	harper-and-row
+Harrassowitz Verlag	2	121	0	156	156	0.7756410256410257	harrassowitz-verlag
+Hart Publishing	1	93	0	0	102	0.9117647058823529	hart-publishing
+Harvard Law Review Association	1	19370	0	19370	19370	1.0	harvard-law-review-association
+Harvard University	2	300	0	552	1392	0.21551724137931033	harvard-university
+Harvard University Press	5	2372	296	2942	3961	0.598838677101742	harvard-university-press
+Harvey Whitney Books Company	1	19	0	0	167	0.11377245508982035	harvey-whitney-books-company
+Harwood Academic Publishers	2	65	0	0	303	0.2145214521452145	harwood-academic-publishers
+Hastings Center	1	670	0	670	670	1.0	hastings-center
+HAU Society for Ethnographic Theory	1	0	448	448	448	0.0	hau-society-for-ethnographic-theory
+Headley Bros. Ltd.	1	107	0	0	2858	0.03743876836948915	headley-bros-ltd
+Health Administration Press	1	30	0	0	30	1.0	health-administration-press
+Health and Medical Publishing Group	1	111	229	229	229	0.4847161572052402	health-and-medical-publishing-group
+Health Information Management Association of Australia	1	11	0	0	11	1.0	health-information-management-association-of-australia
+Health Research User's Trust Fund	2	1	74	74	433	0.0023094688221709007	health-research-users-trust-fund
+Health Services And Mental Health Administration	1	158	0	0	158	1.0	health-services-and-mental-health-administration
+Healthcare Bulletin	1	50	0	0	58	0.8620689655172413	healthcare-bulletin
+Hebrew Union College	1	3	0	0	10	0.3	hebrew-union-college
+Hellenic Cardiological Society	1	135	0	160	160	0.84375	hellenic-cardiological-society
+Hellenic Endocrine Society	1	0	0	551	551	0.0	hellenic-endocrine-society
+Hellenic Society of Gastroenterology	1	0	133	133	133	0.0	hellenic-society-of-gastroenterology
+Hellenic Society of Medical Oncology (He.S.M.O.)	1	10	37	37	37	0.2702702702702703	hellenic-society-of-medical-oncology-he-s-m-o
+Hellenike Psychiatrike Hetaireia	1	0	0	22	22	0.0	hellenike-psychiatrike-hetaireia
+Helminthological Society of Washington	1	708	0	727	727	0.9738651994497937	helminthological-society-of-washington
+Hemisphere Publishing Corp.	2	467	0	0	468	0.9978632478632479	hemisphere-publishing-corp
+Henley-Putnam University Press	1	3	349	349	349	0.008595988538681949	henley-putnam-university-press
+Henry Stewart Publications	1	225	0	0	458	0.4912663755458515	henry-stewart-publications
+Hepatia Press	2	0	51	94	94	0.0	hepatia-press
+Herbarium Mediterraneum Panormitanum	1	0	0	120	120	0.0	herbarium-mediterraneum-panormitanum
+Hermes	1	0	0	0	1929	0.0	hermes
+Herpetological Society of Japan	1	214	0	288	288	0.7430555555555556	herpetological-society-of-japan
+Herpetologists League	2	941	0	948	948	0.9926160337552743	herpetologists-league
+Heterocorporation	1	6577	0	0	7615	0.8636900853578463	heterocorporation
+Heyden And Son	1	657	0	0	657	1.0	heyden-and-son
+HFSP Publishing	1	138	0	0	153	0.9019607843137255	hfsp-publishing
+Higher Education Academy	3	253	263	0	608	0.4161184210526316	higher-education-academy
+Higher Education Press	5	3272	0	3335	3335	0.9811094452773613	higher-education-press
+Hikari Ltd.	1	9	616	0	616	0.01461038961038961	hikari-ltd
+Hindawi	223	63655	130263	142379	152050	0.41864518250575466	hindawi
+Hippiatrika Verlag GmbH	1	0	0	1374	1374	0.0	hippiatrika-verlag-gmbh
+Hippokrates Verlag	1	627	0	1117	1117	0.5613249776186213	hippokrates-verlag
+Hirzel Verlag	2	1117	0	1056	1207	0.9254349627174814	hirzel-verlag
+Histochemical Society	1	9098	0	9154	9154	0.9938824557570461	histochemical-society
+Historical Society of Pennsylvania	1	378	0	437	437	0.8649885583524027	historical-society-of-pennsylvania
+Historical Society of Southern California	1	2853	0	0	3033	0.9406528189910979	historical-society-of-southern-california
+History of the Earth Sciences Society	1	0	0	666	666	0.0	history-of-the-earth-sciences-society
+Hodder Arnold Journals	3	27	0	0	290	0.09310344827586207	hodder-arnold-journals
+Hodges and Smith	3	7530	0	0	7530	1.0	hodges-and-smith
+Hofstra University Press	1	1153	0	1376	1376	0.8379360465116279	hofstra-university-press
+Hogrefe Publishing	24	273	0	14527	15469	0.017648199625056565	hogrefe-publishing
+Hong Kong Academy of Medicine Press	2	8	434	628	628	0.012738853503184714	hong-kong-academy-of-medicine-press
+Hong Kong Asiamed Publishing House	1	421	426	426	426	0.9882629107981221	hong-kong-asiamed-publishing-house
+Hong Kong Physiotherapy Association	1	351	352	352	352	0.9971590909090909	hong-kong-physiotherapy-association
+Hong Kong Society for Transportation Studies Limited	1	137	0	0	137	1.0	hong-kong-society-for-transportation-studies-limited
+Horticultural Society of India	1	0	0	241	241	0.0	horticultural-society-of-india
+Hosokawa Powder Technology Foundation	1	0	929	929	929	0.0	hosokawa-powder-technology-foundation
+Hospital Infantil de Mexico Federico Gomez	1	165	0	185	185	0.8918918918918919	hospital-infantil-de-mexico-federico-gomez
+Howard University Press	1	4779	0	4874	4874	0.9805088223225277	howard-university-press
+Hrvatski Prirodoslovni Muzej/Croatian Natural History Museum	1	0	0	16	16	0.0	hrvatski-prirodoslovni-muzej-croatian-natural-history-museum
+Hrvatsko Drustvo Gradevinskih Inzenjera	1	2	0	192	192	0.010416666666666666	hrvatsko-drustvo-gradevinskih-inzenjera
+Hrvatsko Drustvo Kemijskih Inzenjera i Tehnologa/Croatian Society of Chemical Engineers	2	76	0	264	264	0.2878787878787879	hrvatsko-drustvo-kemijskih-inzenjera-i-tehnologa-croatian-society-of-chemical-engineers
+Hrvatsko drustvo medicinskih biokemicara	1	1	0	1	1	1.0	hrvatsko-drustvo-medicinskih-biokemicara
+Hrvatsko Farmaceutsko Drustvo/Croatian Pharmaceutical Society	1	289	300	300	300	0.9633333333333334	hrvatsko-farmaceutsko-drustvo-croatian-pharmaceutical-society
+Hrvatsko Filolosko Drustvo/Croatian Philological Society	1	0	36	36	36	0.0	hrvatsko-filolosko-drustvo-croatian-philological-society
+Hrvatsko Geografsko Drustvo/Croatian Geographical Society	1	0	0	11	11	0.0	hrvatsko-geografsko-drustvo-croatian-geographical-society
+Hrvatsko Kemijsko Drustvo/Croatian Chemical Society	1	243	392	392	392	0.6198979591836735	hrvatsko-kemijsko-drustvo-croatian-chemical-society
+Hrvatsko Prirodoslovno Drustvo/Croation Society of Natural Sciences	1	0	73	73	73	0.0	hrvatsko-prirodoslovno-drustvo-croation-society-of-natural-sciences
+Hrvatsko sociolosko drustvo	2	0	131	131	131	0.0	hrvatsko-sociolosko-drustvo
+Huazhong University of Science and Technology	3	4223	0	3192	4237	0.9966957753127212	huazhong-university-of-science-and-technology
+Hudson Review	1	6214	0	0	6214	1.0	hudson-review
+Human Geographical Society of Japan	1	0	0	2559	2559	0.0	human-geographical-society-of-japan
+Human Justice Collective	1	78	0	0	78	1.0	human-justice-collective
+Human Kinetics Publishers Inc.	22	18901	0	16948	19436	0.9724737600329286	human-kinetics-publishers-inc
+Human Nature Review	1	703	724	724	724	0.9709944751381215	human-nature-review
+Human Sciences Press	8	5297	0	0	5324	0.9949286250939143	human-sciences-press
+Humanitas	1	16	0	440	440	0.03636363636363636	humanitas
+Humboldt Field Research Institute	2	2361	0	2444	2444	0.9660392798690671	humboldt-field-research-institute
+Hungarian Academy of Sciences, Geographical Research Institute	1	0	91	91	91	0.0	hungarian-academy-of-sciences-geographical-research-institute
+Hungarian Central Statistical Office	1	0	0	56	56	0.0	hungarian-central-statistical-office
+Hungarian Communication Studies Association	1	0	57	57	57	0.0	hungarian-communication-studies-association
+Hüthig	1	2311	0	0	4144	0.5576737451737451	huthig
+I.M. Sechenov First Moscow State Medical University	1	0	0	138	138	0.0	i-m-sechenov-first-moscow-state-medical-university
+I.U. Tip Fakultesi K.B.B. Anabilim Dali	1	4	0	406	406	0.009852216748768473	i-u-tip-fakultesi-k-b-b-anabilim-dali
+IATSS - International Association of Traffic and Safety Sciences	1	1900	2040	2040	2040	0.9313725490196079	iatss-international-association-of-traffic-and-safety-sciences
+IBM Corp.	2	5381	0	4502	6391	0.8419652636520106	ibm-corp
+Ibn Sina Trust	1	149	675	675	675	0.22074074074074074	ibn-sina-trust
+IBP - International Business Press Publishers	1	160	0	0	164	0.975609756097561	ibp-international-business-press-publishers
+ICE Publishing	22	15571	0	17359	17545	0.8874893131946423	ice-publishing
+Icelandic Medical Association and the Medical Society of Reykjavik	1	0	114	114	114	0.0	icelandic-medical-association-and-the-medical-society-of-reykjavik
+ID Design Press	1	2	0	458	458	0.004366812227074236	id-design-press
+IFAC Secretariat	1	5334	0	5485	5485	0.9724703737465816	ifac-secretariat
+Ifjusagi Lapkiado Vallalat	1	12	0	596	596	0.020134228187919462	ifjusagi-lapkiado-vallalat
+Igaku Shoin Ltd.	1	1023	0	0	1027	0.9961051606621227	igaku-shoin-ltd
+IGI Global	55	150	0	10051	10213	0.014687163419171643	igi-global
+Igitur, Utrecht Publishing and Archiving Services	2	0	2479	2479	2479	0.0	igitur-utrecht-publishing-and-archiving-services
+Ignis Publications	1	51	0	99	99	0.5151515151515151	ignis-publications
+II Pensiero Scientifico Editore srl	2	701	0	405	1108	0.6326714801444043	ii-pensiero-scientifico-editore-srl
+IJESE	1	0	0	0	20	0.0	ijese
+Il Ponte	1	134	0	0	134	1.0	il-ponte
+Illuminating Engineering Institute of Japan	2	0	0	6069	6069	0.0	illuminating-engineering-institute-of-japan
+Illuminating Engineering Society of North America	1	1354	0	0	1358	0.9970544918998527	illuminating-engineering-society-of-north-america
+ILTPE-B. Verkin Institute for Low Temperature Physics and Engineering of the National Academy of Sciences of Ukraine	1	0	58	58	58	0.0	iltpe-b-verkin-institute-for-low-temperature-physics-and-engineering-of-the-national-academy-of-sciences-of-ukraine
+IM Publications	1	1284	0	0	1339	0.958924570575056	im-publications
+Ima-Press Publishing House	2	3	0	1918	1918	0.0015641293013555788	ima-press-publishing-house
+iMedPub	1	0	0	0	100	0.0	imedpub
+Impact Journals	2	1	15539	15878	15878	6.298022420959819e-5	impact-journals
+Imperial College Press	1	243	0	0	271	0.8966789667896679	imperial-college-press
+Imprensa da Universidade de Coimbra	1	0	0	39	39	0.0	imprensa-da-universidade-de-coimbra
+Imprimerie Nationale	1	0	0	1845	1845	0.0	imprimerie-nationale
+In House Publications	2	3	0	69	580	0.005172413793103448	in-house-publications
+Incisive Media Ltd.	5	0	0	1227	1227	0.0	incisive-media-ltd
+Inderscience	232	63378	0	69251	70214	0.9026404990457744	inderscience
+Indian Academy of Forensic Medicine	1	0	0	242	242	0.0	indian-academy-of-forensic-medicine
+Indian Academy of Neurosciences	1	201	565	565	565	0.35575221238938054	indian-academy-of-neurosciences
+Indian Academy of Sciences	6	8115	7400	8067	8859	0.9160176092109719	indian-academy-of-sciences
+Indian Council of Medical Research	1	0	630	630	630	0.0	indian-council-of-medical-research
+Indian Institute of Science	1	5	0	9	9	0.5555555555555556	indian-institute-of-science
+Indian National Science Academy	2	328	0	743	743	0.4414535666218035	indian-national-science-academy
+Indian Pacing and Electrophysiology Group	1	294	313	313	313	0.939297124600639	indian-pacing-and-electrophysiology-group
+Indian Physical Society	1	1497	0	1515	1515	0.9881188118811881	indian-physical-society
+Indian Society for Education and Environment	1	0	0	0	7112	0.0	indian-society-for-education-and-environment
+Indian Society for Surface Science and Technology	1	0	0	9	9	0.0	indian-society-for-surface-science-and-technology
+Indian Society of Agricultural Biochemists	1	0	0	53	53	0.0	indian-society-of-agricultural-biochemists
+Indian Society of Gastroenterology	1	803	0	816	816	0.9840686274509803	indian-society-of-gastroenterology
+Indian Society of Genetics & Plant Breeding.	1	5	0	341	341	0.01466275659824047	indian-society-of-genetics-plant-breeding
+Indian Society of Plant Breeders	1	0	60	60	60	0.0	indian-society-of-plant-breeders
+Indian Society of Soil Science	1	0	0	75	75	0.0	indian-society-of-soil-science
+Indian Sociological Society	1	0	0	0	1125	0.0	indian-sociological-society
+Indian Virological Society	1	166	0	0	166	1.0	indian-virological-society
+Indiana University Press	18	5379	0	18996	20066	0.2680653842320343	indiana-university-press
+Indo-Pacific Prehistory Association	1	0	0	0	592	0.0	indo-pacific-prehistory-association
+Indonesia University of Education	1	0	163	163	163	0.0	indonesia-university-of-education
+Indonesian Combinatorics Society	1	0	0	69	69	0.0	indonesian-combinatorics-society
+Industrial Chemistry Research Institute	1	0	0	489	489	0.0	industrial-chemistry-research-institute
+Industrial Research Institute for Automation and Measurements	1	32	116	116	116	0.27586206896551724	industrial-research-institute-for-automation-and-measurements
+Infection Control Nurses Association	1	321	0	0	321	1.0	infection-control-nurses-association
+Informatics India Ltd	1	317	0	317	317	1.0	informatics-india-ltd
+Information Center for the Environment, University of California Davis	1	0	199	199	199	0.0	information-center-for-the-environment-university-of-california-davis
+Information Processing Society of Japan	5	1081	0	1144	1144	0.9449300699300699	information-processing-society-of-japan
+Information Retrieval	1	2022	0	0	2022	1.0	information-retrieval
+Information Today, Inc.	1	176	0	0	176	1.0	information-today-inc
+Iniestares S.A.	1	0	0	1025	1025	0.0	iniestares-s-a
+InnoVision Communications	1	0	0	0	187	0.0	innovision-communications
+INSIGHT - Indonesian Society for Knowledge and Human Development	1	0	787	787	787	0.0	insight-indonesian-society-for-knowledge-and-human-development
+Inst of Wood Science	1	83	0	0	83	1.0	inst-of-wood-science
+Inst za Drvo	1	1	0	212	212	0.0047169811320754715	inst-za-drvo
+Institut Botanic de Barcelona	1	1	199	199	199	0.005025125628140704	institut-botanic-de-barcelona
+Institut d'Histoire de I'Amerique Francaise	1	3689	0	5860	5860	0.6295221843003413	institut-dhistoire-de-iamerique-francaise
+Institut de Geographie	1	1	0	480	480	0.0020833333333333333	institut-de-geographie
+Institut de Linguistique de l'Universite	1	0	0	0	540	0.0	institut-de-linguistique-de-luniversite
+Institut de Sciences Mathematiques et Economiques Appliquees FRA	1	26	0	602	602	0.04318936877076412	institut-de-sciences-mathematiques-et-economiques-appliquees-fra
+Institut des Hautes Etudes de l'Amerique Latine (IHEAL)	1	0	225	225	225	0.0	institut-des-hautes-etudes-de-lamerique-latine-iheal
+Institut Drustvenih Znanosti lvo Pilar/Institute of Social Sciences lvo Pilar	1	2	0	272	272	0.007352941176470588	institut-drustvenih-znanosti-lvo-pilar-institute-of-social-sciences-lvo-pilar
+Institut Francais d'Etudes Andines	1	0	0	0	594	0.0	institut-francais-detudes-andines
+Institut Francais du Proche-Orient	1	1	0	1325	1325	7.547169811320754e-4	institut-francais-du-proche-orient
+Institut International d'administration Publique	1	42	0	951	951	0.04416403785488959	institut-international-dadministration-publique
+Institut Mathematique	1	7	0	457	457	0.015317286652078774	institut-mathematique
+Institut Meditsiny Truda	1	0	0	2	2	0.0	institut-meditsiny-truda
+Institut Nacional d'Educacio Fisica de Catalunya	1	50	407	407	407	0.12285012285012285	institut-nacional-deducacio-fisica-de-catalunya
+Institut National D Etudes Demographiques	1	10266	0	10705	10705	0.9589911256422232	institut-national-d-etudes-demographiques
+Institut National d'histoire de l'art	2	0	0	208	208	0.0	institut-national-dhistoire-de-lart
+Institut national de la recherche agronomique	1	1	0	0	1491	6.706908115358819e-4	institut-national-de-la-recherche-agronomique
+Institut National de la Research Scientifique	1	539	0	771	771	0.6990920881971465	institut-national-de-la-research-scientifique
+Institut national de la statistique et des etudes economiques	1	18	0	2744	2744	0.006559766763848397	institut-national-de-la-statistique-et-des-etudes-economiques
+Institut National de Recherche Pedagogique	4	4	0	2672	2775	0.0014414414414414415	institut-national-de-recherche-pedagogique
+Institut Sociologii RAN	1	0	0	187	187	0.0	institut-sociologii-ran
+Institut Teknologi Bandung (ITB)	4	41	223	223	398	0.10301507537688442	institut-teknologi-bandung-itb
+Institut Veolia Environnement	2	0	28	28	28	0.0	institut-veolia-environnement
+Institut za Drustvena Istrazivanja u Zagrebu	1	0	146	146	146	0.0	institut-za-drustvena-istrazivanja-u-zagrebu
+Institut za Etnologiju i Folkloristiku	1	0	67	67	67	0.0	institut-za-etnologiju-i-folkloristiku
+Institut za Istrazivanja I Projektovanja u Privredi	1	1	0	200	200	0.005	institut-za-istrazivanja-i-projektovanja-u-privredi
+Institut za kovinske materiale in tehnologije Ljubljana	1	0	311	311	311	0.0	institut-za-kovinske-materiale-in-tehnologije-ljubljana
+Institut za Lokalno Samoupravo in Javna Narocila	1	0	0	193	193	0.0	institut-za-lokalno-samoupravo-in-javna-narocila
+Institut za Pedagoska Istrazivanja	1	3	295	295	295	0.010169491525423728	institut-za-pedagoska-istrazivanja
+Institute de Investigaciones Agropecuarias	2	138	631	631	1029	0.13411078717201166	institute-de-investigaciones-agropecuarias
+Institute for Advanced Studies, Department of Political Science	1	0	24	24	24	0.0	institute-for-advanced-studies-department-of-political-science
+Institute for Cognitive Science at Seoul National University	1	0	0	152	152	0.0	institute-for-cognitive-science-at-seoul-national-university
+Institute for Condensed Matter Physics of the National Academy of Sciences of Ukraine	1	17	1309	1309	1309	0.012987012987012988	institute-for-condensed-matter-physics-of-the-national-academy-of-sciences-of-ukraine
+Institute for Ethnographic Research	1	1297	0	2142	2142	0.6055088702147525	institute-for-ethnographic-research
+Institute for International Relations	1	8	40	40	40	0.2	institute-for-international-relations
+Institute for Ionics	1	2797	0	2846	2846	0.982782853127196	institute-for-ionics
+Institute for Medical Research and Occupational Health	1	447	476	476	476	0.9390756302521008	institute-for-medical-research-and-occupational-health
+Institute for Metals Superplasticity Problems of Russian Academy of Sciences	1	0	441	441	441	0.0	institute-for-metals-superplasticity-problems-of-russian-academy-of-sciences
+Institute for Operations Research and the Management Sciences	11	26645	3525	29091	29091	0.9159190127530852	institute-for-operations-research-and-the-management-sciences
+Institute for Philosophy and Public Policy	2	0	0	0	162	0.0	institute-for-philosophy-and-public-policy
+Institute for Research and Community Services, Institut Teknologi Bandung	2	1	101	101	241	0.004149377593360996	institute-for-research-and-community-services-institut-teknologi-bandung
+Institute for Social Science, Belgrade	1	0	113	113	113	0.0	institute-for-social-science-belgrade
+Institute for the Study of Language and Information, Kyung Hee University	1	0	0	278	278	0.0	institute-for-the-study-of-language-and-information-kyung-hee-university
+Institute of Advanced Engineering and Science (IAES)	4	1	1842	2857	2857	0.00035001750087504374	institute-of-advanced-engineering-and-science-iaes
+Institute of Agricultural Medicine	1	4	514	514	514	0.007782101167315175	institute-of-agricultural-medicine
+Institute of Applied Biochemistry	1	33	0	1583	1583	0.020846493998736577	institute-of-applied-biochemistry
+Institute of archaeology and ethnography SB RAS	1	717	0	774	774	0.9263565891472868	institute-of-archaeology-and-ethnography-sb-ras
+Institute of Architecture and Urban & Spatial Planning of Serbia (IAUS)	1	0	237	237	237	0.0	institute-of-architecture-and-urban-spatial-planning-of-serbia-iaus
+Institute of Biological Sciences, Rajshahi University	1	1	0	0	199	0.005025125628140704	institute-of-biological-sciences-rajshahi-university
+Institute of Botany	1	1207	0	0	1207	1.0	institute-of-botany
+Institute of Chemical Engineers	1	4606	0	4663	4663	0.9877761098005576	institute-of-chemical-engineers
+Institute of Chemical Fibres	1	0	0	199	199	0.0	institute-of-chemical-fibres
+Institute of Chemistry, Academy of Sciences of Moldova	1	0	119	119	119	0.0	institute-of-chemistry-academy-of-sciences-of-moldova
+Institute of Chemistry, Technology and Metallurgy	1	115	381	381	381	0.30183727034120733	institute-of-chemistry-technology-and-metallurgy
+Institute of Computer Science, Izhevsk	1	0	0	499	499	0.0	institute-of-computer-science-izhevsk
+Institute of Control, Robotics and Systems	1	1	0	1552	1552	6.443298969072165e-4	institute-of-control-robotics-and-systems
+Institute of Croatian History, Faculty of Philosophy Zagreb	1	0	55	55	55	0.0	institute-of-croatian-history-faculty-of-philosophy-zagreb
+Institute of Crop Sciences (ICS)	1	234	243	243	243	0.9629629629629629	institute-of-crop-sciences-ics
+Institute of Cytology and Genetics of Siberian Branch of the Russian Academy of Sciences	1	0	0	98	98	0.0	institute-of-cytology-and-genetics-of-siberian-branch-of-the-russian-academy-of-sciences
+Institute of Development Studies, Sussex, University of Sussex	1	1860	1954	1954	1954	0.9518935516888434	institute-of-development-studies-sussex-university-of-sussex
+Institute of Ecology of Vilnius University	1	764	0	0	764	1.0	institute-of-ecology-of-vilnius-university
+Institute of Economics, The Ural Branch of Russian Academy of Sciences	1	0	816	816	816	0.0	institute-of-economics-the-ural-branch-of-russian-academy-of-sciences
+Institute of Electrical and Electronics Engineers	305	881253	4562	768287	893756	0.9860107232846549	institute-of-electrical-and-electronics-engineers
+Institute of Electrical Engineers	52	70531	0	55046	105416	0.6690730059952948	institute-of-electrical-engineers
+Institute of Electronics Chinese Academy of Sciences	1	0	0	115	115	0.0	institute-of-electronics-chinese-academy-of-sciences
+Institute of Electronics, Information and Communication Engineers	1	2886	0	3017	3017	0.9565793834935367	institute-of-electronics-information-and-communication-engineers
+Institute of Energy	1	13	0	0	18	0.7222222222222222	institute-of-energy
+Institute of Environmental Sciences and Technology	1	0	0	0	258	0.0	institute-of-environmental-sciences-and-technology
+Institute of Europe of Russian Academy of Sciences	1	1	0	194	194	0.005154639175257732	institute-of-europe-of-russian-academy-of-sciences
+Institute of Geology Istrazivanja/Institue of Geology	1	33	0	0	133	0.24812030075187969	institute-of-geology-istrazivanja-institue-of-geology
+Institute of Geology Zagreb	1	17	115	115	115	0.14782608695652175	institute-of-geology-zagreb
+Institute of Health Promotion and Education	1	9	0	0	9	1.0	institute-of-health-promotion-and-education
+Institute of Image Information and Television Engineers	2	1	0	191	3799	2.6322716504343247e-4	institute-of-image-information-and-television-engineers
+Institute of Industrial Organic Chemistry	1	0	84	84	84	0.0	institute-of-industrial-organic-chemistry
+Institute of Information and Communication Technologies, Bulgarian Academy of Sciences	1	118	321	321	321	0.367601246105919	institute-of-information-and-communication-technologies-bulgarian-academy-of-sciences
+Institute of Malacology	1	219	0	219	219	1.0	institute-of-malacology
+Institute of Mathematical Problems of Biology	1	2	0	282	282	0.0070921985815602835	institute-of-mathematical-problems-of-biology
+Institute of Mathematical Statistics	11	6338	3187	16535	16535	0.3833081342606592	institute-of-mathematical-statistics
+Institute of Mathematics and Informatics	2	1	44	139	139	0.007194244604316547	institute-of-mathematics-and-informatics
+Institute of Mathematics at the Academy of Sciences of Moldova	1	0	0	1	1	0.0	institute-of-mathematics-at-the-academy-of-sciences-of-moldova
+Institute of Mathematics with Computer Center of Russian Academy of Sciences	1	0	0	34	34	0.0	institute-of-mathematics-with-computer-center-of-russian-academy-of-sciences
+Institute of Mathematics, Polish Academy of Sciences	2	58	0	1474	1474	0.03934871099050204	institute-of-mathematics-polish-academy-of-sciences
+Institute of Measurement Science	1	244	356	356	356	0.6853932584269663	institute-of-measurement-science
+Institute of New Chemical Technologies and Materials of Al-Farabi Kazakh State National University	1	0	0	389	389	0.0	institute-of-new-chemical-technologies-and-materials-of-al-farabi-kazakh-state-national-university
+Institute of Noise Control Engineering	2	1471	0	1240	1511	0.9735274652547982	institute-of-noise-control-engineering
+Institute of Nuclear Chemistry and Technology	1	134	256	256	256	0.5234375	institute-of-nuclear-chemistry-and-technology
+Institute of Oncology Sremska Kamenica	1	110	0	0	476	0.23109243697478993	institute-of-oncology-sremska-kamenica
+Institute of Paper Conservation	1	316	0	0	316	1.0	institute-of-paper-conservation
+Institute of Physical Optics	1	0	0	445	445	0.0	institute-of-physical-optics
+Institute of Physics	73	426159	65757	352527	448312	0.9505857527793145	institute-of-physics
+Institute of Physics Publishing	14	114696	0	221097	221097	0.5187587348539329	institute-of-physics-publishing
+Institute of Pure and Applied Physics	2	36377	0	38356	55885	0.6509260087680058	institute-of-pure-and-applied-physics
+Institute of Society Transformation	1	0	0	175	175	0.0	institute-of-society-transformation
+Institute of Southeast Asian Studies	2	291	0	1623	1623	0.17929759704251386	institute-of-southeast-asian-studies
+Institute of Special Education and Rehabilitation	1	18	93	93	93	0.1935483870967742	institute-of-special-education-and-rehabilitation
+Institute of the Earth's Crust	1	0	229	229	229	0.0	institute-of-the-earths-crust
+Institution of Chemical Engineers	2	3504	0	3535	3535	0.9912305516265912	institution-of-chemical-engineers
+Institution of Electronic and Radio Engineers	2	2669	0	0	3024	0.8826058201058201	institution-of-electronic-and-radio-engineers
+Institution of Engineering and Technology	24	20366	0	22147	22297	0.9133964210431896	institution-of-engineering-and-technology
+Institution of Production Engineers	1	1597	0	0	4829	0.3307102919859184	institution-of-production-engineers
+Institution of Russian Academy of Sciences, Image Processing Systems Institute of RAS	1	0	0	400	400	0.0	institution-of-russian-academy-of-sciences-image-processing-systems-institute-of-ras
+Institution of Surveyors Australia Inc.	1	4612	0	0	4648	0.9922547332185886	institution-of-surveyors-australia-inc
+Institutional Investor Systems	5	5062	0	5420	5420	0.9339483394833948	institutional-investor-systems
+Institutional Investor, Inc.	1	145	0	163	163	0.8895705521472392	institutional-investor-inc
+Institutional National de Cercetare-Dezvoltare Pentru Texttile Pielarie	1	0	0	78	78	0.0	institutional-national-de-cercetare-dezvoltare-pentru-texttile-pielarie
+Instituto Agronomico	1	2	3114	3114	3114	6.422607578676942e-4	instituto-agronomico
+Instituto Brasileiro de Avaliacao Psicologica	1	0	0	80	80	0.0	instituto-brasileiro-de-avaliacao-psicologica
+Instituto Brasileiro de Bibliografia e Documentacao. Conselho nacional de pesquisas	1	0	0	553	553	0.0	instituto-brasileiro-de-bibliografia-e-documentacao-conselho-nacional-de-pesquisas
+Instituto Brasileiro de Economia	1	1	381	381	381	0.0026246719160104987	instituto-brasileiro-de-economia
+Instituto Brasileiro de Estudos e Pesquisas de Gastroenterologia/Brazilian Institute for Studies and Research in Gastroenterology	1	2	845	845	845	0.002366863905325444	instituto-brasileiro-de-estudos-e-pesquisas-de-gastroenterologia-brazilian-institute-for-studies-and-research-in-gastroenterology
+Instituto Colombiano de Antropologia e Historia	1	0	0	80	80	0.0	instituto-colombiano-de-antropologia-e-historia
+Instituto de Aeronautica e Espaco-IAE	1	6	353	353	353	0.0169971671388102	instituto-de-aeronautica-e-espaco-iae
+Instituto de Analisis Semiotico del Discurso	1	0	26	26	26	0.0	instituto-de-analisis-semiotico-del-discurso
+Instituto de Botanica Darwinion	1	20	45	45	45	0.4444444444444444	instituto-de-botanica-darwinion
+Instituto de Ciencias de Ia Construccion Eduardo Torroja	1	3	1531	1531	1531	0.001959503592423253	instituto-de-ciencias-de-ia-construccion-eduardo-torroja
+Instituto de Desarrollo Economico y Social	1	1530	0	1530	1530	1.0	instituto-de-desarrollo-economico-y-social
+Instituto de Ecologia	2	0	0	1131	1131	0.0	instituto-de-ecologia
+Instituto de Economa da Universidade Federal do Rio de Janeiro	1	0	7	7	7	0.0	instituto-de-economa-da-universidade-federal-do-rio-de-janeiro
+Instituto de Ensino e Pesquisa Albert Einstein	1	1	0	2	2	0.5	instituto-de-ensino-e-pesquisa-albert-einstein
+Instituto de Estudios Fiscales	1	0	0	54	54	0.0	instituto-de-estudios-fiscales
+Instituto de Fisica de Liquidos y Sistemas Biologicos	1	1	0	82	82	0.012195121951219513	instituto-de-fisica-de-liquidos-y-sistemas-biologicos
+Instituto de geociencias da Universidade de Sao Paulo	1	0	308	308	308	0.0	instituto-de-geociencias-da-universidade-de-sao-paulo
+Instituto de Investigaciones Dr. Jose Maria Luis Mora	1	0	488	488	488	0.0	instituto-de-investigaciones-dr-jose-maria-luis-mora
+Instituto de Investigaciones Economicas, UNAM	1	202	206	206	206	0.9805825242718447	instituto-de-investigaciones-economicas-unam
+Instituto de la Grasa	1	256	1306	1306	1306	0.19601837672281777	instituto-de-la-grasa
+Instituto de la Patagonia, Universidad de Magallanes	1	1	398	398	398	0.002512562814070352	instituto-de-la-patagonia-universidad-de-magallanes
+Instituto de Medicina Social da Universidade do Estado do Rio de Janeiro	1	0	943	943	943	0.0	instituto-de-medicina-social-da-universidade-do-estado-do-rio-de-janeiro
+Instituto de Pesca	1	0	81	81	81	0.0	instituto-de-pesca
+Instituto de Pesquisas Ambientais em Bacias Hidrograficas (IPABHi)	1	0	643	643	643	0.0	instituto-de-pesquisas-ambientais-em-bacias-hidrograficas-ipabhi
+Instituto de Pesquisas Economicas	1	0	423	423	423	0.0	instituto-de-pesquisas-economicas
+Instituto de Tecnologia de Alimentos (ITAL)	1	3	412	412	412	0.007281553398058253	instituto-de-tecnologia-de-alimentos-ital
+Instituto de Tecnologia do Parana	1	26	2029	2029	2029	0.012814194184327254	instituto-de-tecnologia-do-parana
+Instituto De Zootecnica	1	0	528	528	528	0.0	instituto-de-zootecnica
+Instituto Espanol de Entomologia del Consejo Superior de Investigaciones Cientificas	1	5	468	468	468	0.010683760683760684	instituto-espanol-de-entomologia-del-consejo-superior-de-investigaciones-cientificas
+Instituto Geologico y Minero de Espana	1	0	0	19	19	0.0	instituto-geologico-y-minero-de-espana
+Instituto Geologico, Secretaria do Meio Ambiente	1	0	0	242	242	0.0	instituto-geologico-secretaria-do-meio-ambiente
+Instituto Internacional de Literatura Iberoamericana	1	0	0	6541	6541	0.0	instituto-internacional-de-literatura-iberoamericana
+Instituto Materno Infantil de Pernambuco	1	0	50	50	50	0.0	instituto-materno-infantil-de-pernambuco
+Instituto Mora	1	0	1267	1267	1267	0.0	instituto-mora
+Instituto Nacional de Cardiologia Ignazio Chavez	1	6	0	343	343	0.01749271137026239	instituto-nacional-de-cardiologia-ignazio-chavez
+Instituto Nacional de Investigacion y Tecnologia Agraria y Alimentaria	3	19	1670	1670	1823	0.010422380691168404	instituto-nacional-de-investigacion-y-tecnologia-agraria-y-alimentaria
+Instituto Nacional de Pesquisas da Amazonica	1	12	943	943	943	0.012725344644750796	instituto-nacional-de-pesquisas-da-amazonica
+Instituto Nacional de Salud	3	11	4663	4663	4663	0.0023589963542783618	instituto-nacional-de-salud
+Instituto Profesional de Estudios Superiores Blas Canas	1	0	0	445	445	0.0	instituto-profesional-de-estudios-superiores-blas-canas
+Instituto Superior de Ciencias do Trabalho e da Empresa	1	0	130	130	130	0.0	instituto-superior-de-ciencias-do-trabalho-e-da-empresa
+Instituto Superior de Psicologia Aplicada	1	26	0	670	670	0.03880597014925373	instituto-superior-de-psicologia-aplicada
+Instituto universitario Ca' Foscari Venezia, Laboratorio di economia politica	1	102	0	0	102	1.0	instituto-universitario-ca-foscari-venezia-laboratorio-di-economia-politica
+Instituto Universitario de Estudios sobre Migraciones	1	0	0	44	44	0.0	instituto-universitario-de-estudios-sobre-migraciones
+Instituto Universitario de Pesquisas do Rio de Janeiro	1	2	456	456	456	0.0043859649122807015	instituto-universitario-de-pesquisas-do-rio-de-janeiro
+Institutul de Cercetara-Dezvoltare Pentru Mecatronica si Tehnical Masurarii (INCDTM)	1	0	0	55	55	0.0	institutul-de-cercetara-dezvoltare-pentru-mecatronica-si-tehnical-masurarii-incdtm
+Institutul Medico Farmaceutic Cluj	1	71	282	282	282	0.25177304964539005	institutul-medico-farmaceutic-cluj
+Instrument Society of America	1	2289	0	2300	2300	0.9952173913043478	instrument-society-of-america
+Instytut Archeologii i Etnologii	1	0	0	18	18	0.0	instytut-archeologii-i-etnologii
+Instytut Matematyczny	1	29	0	1921	1921	0.015096304008328995	instytut-matematyczny
+Instytut Medycyny Pracy im. Jerzego Nofera/Nofer Institute of Occupational Medicine	1	1	324	324	324	0.0030864197530864196	instytut-medycyny-pracy-im-jerzego-nofera-nofer-institute-of-occupational-medicine
+Instytut Psychiatrii I Neurologii	1	107	0	109	109	0.981651376146789	instytut-psychiatrii-i-neurologii
+Instytut Sportu/Institute of Sport	1	18	371	371	371	0.04851752021563342	instytut-sportu-institute-of-sport
+Intangible Capital	1	1	277	277	277	0.0036101083032490976	intangible-capital
+InTech	2	85	420	420	420	0.20238095238095238	intech
+Intellect Ltd.	4	435	0	491	491	0.8859470468431772	intellect-ltd
+Intellect Publishers	32	6861	0	7419	7555	0.9081403044341496	intellect-publishers
+Intelligent Networks and Systems Society	1	0	0	193	193	0.0	intelligent-networks-and-systems-society
+Inter-Research	1	29	226	226	226	0.12831858407079647	inter-research
+Inter-Research Science Center	2	274	1548	1548	1548	0.17700258397932817	inter-research-science-center
+Inter-Research Science Publishing	5	2741	172	22164	22164	0.12366901281357155	inter-research-science-publishing
+Interdisciplinary Social Sciences	1	0	0	31	31	0.0	interdisciplinary-social-sciences
+Intermediate Technology Publications Ltd.	2	187	0	1600	2405	0.07775467775467776	intermediate-technology-publications-ltd
+International Academic Press	1	0	151	151	151	0.0	international-academic-press
+International Academy of Business and Economics	2	0	0	0	406	0.0	international-academy-of-business-and-economics
+International Advancement Center for Medicine & Health Research Co., Ltd. (IACMHR Co., Ltd.)	3	398	0	846	846	0.47044917257683216	international-advancement-center-for-medicine-health-research-co-ltd-iacmhr-co-ltd
+International AIDS Society	1	966	2373	2373	2373	0.40707964601769914	international-aids-society
+International and American Associations for Dental Research	1	356	0	0	431	0.8259860788863109	international-and-american-associations-for-dental-research
+International Association for Ambulatory Surgery	1	859	0	861	861	0.9976771196283392	international-association-for-ambulatory-surgery
+International Association for Bear Research and Management, University of Tennessee	1	280	0	283	283	0.9893992932862191	international-association-for-bear-research-and-management-university-of-tennessee
+International Association for Bridge and Structural Engineering	1	2154	0	2183	2183	0.9867155290884104	international-association-for-bridge-and-structural-engineering
+International Association for Court Administration	1	0	0	133	133	0.0	international-association-for-court-administration
+International Association for Dental Research	1	625	0	822	822	0.7603406326034063	international-association-for-dental-research
+International Association for Energy Economics	2	1	0	1998	1998	5.005005005005005e-4	international-association-for-energy-economics
+International Association for Food Protection	1	1710	0	10490	10490	0.16301239275500476	international-association-for-food-protection
+International Association for Great Lakes Research	1	3710	0	3723	3723	0.9965081923180231	international-association-for-great-lakes-research
+International Association for Landscape Ecology, Chapter Germany (IALE-D)	1	3	51	51	51	0.058823529411764705	international-association-for-landscape-ecology-chapter-germany-iale-d
+International Association for Plant Taxonomy	1	8577	0	8769	8769	0.9781046869654465	international-association-for-plant-taxonomy
+International Association for Shell and Spatial Structures	1	0	0	28	28	0.0	international-association-for-shell-and-spatial-structures
+International Association for the Study of the Commons	1	0	511	511	511	0.0	international-association-for-the-study-of-the-commons
+International Association of Computer Science & Information Technology	1	0	0	0	24	0.0	international-association-of-computer-science-information-technology
+International Association of Computer Science in Sport	1	6	0	7	7	0.8571428571428571	international-association-of-computer-science-in-sport
+International Association of Lowland Technology	1	0	0	63	63	0.0	international-association-of-lowland-technology
+International Association of Traffic and Safety Sciences	1	402	413	413	413	0.9733656174334141	international-association-of-traffic-and-safety-sciences
+International Association of Yoga Therapists (IAYT)	1	0	0	0	45	0.0	international-association-of-yoga-therapists-iayt
+International Bee Research Association	1	1066	0	0	6510	0.16374807987711212	international-bee-research-association
+International Center for Public Enterprises in Developing Countries	1	0	0	0	7	0.0	international-center-for-public-enterprises-in-developing-countries
+International Center of Mental Health Policy and Economics	1	95	0	133	133	0.7142857142857143	international-center-of-mental-health-policy-and-economics
+International Centre for Applied Thermodynamics	1	2	0	164	164	0.012195121951219513	international-centre-for-applied-thermodynamics
+International Centre for Sustainable Development of Energy, Water and Environment Systems SDEWES	1	0	0	153	153	0.0	international-centre-for-sustainable-development-of-energy-water-and-environment-systems-sdewes
+International College of Surgeons	1	456	0	798	798	0.5714285714285714	international-college-of-surgeons
+International Computer Games Association	1	9	0	473	473	0.019027484143763214	international-computer-games-association
+International Council for Traditional Music	1	1326	0	1392	1392	0.9525862068965517	international-council-for-traditional-music
+International Digital Organization for Scientific Information	1	0	0	0	1	0.0	international-digital-organization-for-scientific-information
+International Dose-Response Society	1	379	410	410	410	0.9243902439024391	international-dose-response-society
+International Federation For Medical Electronics	1	225	0	0	225	1.0	international-federation-for-medical-electronics
+International Food and Agribusiness Management Association	1	133	133	133	133	1.0	international-food-and-agribusiness-management-association
+International Heart Journal Association	1	0	0	1202	1202	0.0	international-heart-journal-association
+International Institute for Aerial Survey and Earth Sciences	1	1598	0	0	1611	0.9919304779639975	international-institute-for-aerial-survey-and-earth-sciences
+International Institute for Art Historical Research (IRSA)	1	547	0	0	547	1.0	international-institute-for-art-historical-research-irsa
+International Institute of Anticancer Research	2	0	0	530	530	0.0	international-institute-of-anticancer-research
+International Institute of Ecology	2	25	1668	1668	1904	0.013130252100840336	international-institute-of-ecology
+International Institute of Political Science and the Masaryk University Press	1	0	0	128	128	0.0	international-institute-of-political-science-and-the-masaryk-university-press
+International Journal of Applied Pharmaceutics	1	0	0	16	16	0.0	international-journal-of-applied-pharmaceutics
+International Journal of Early Childhood Special Education	1	0	0	98	98	0.0	international-journal-of-early-childhood-special-education
+International Journal of Mechanical Engineering and Robotics Research	1	0	0	95	95	0.0	international-journal-of-mechanical-engineering-and-robotics-research
+International Journal of Pharma and Bio Sciences	1	0	366	0	366	0.0	international-journal-of-pharma-and-bio-sciences
+International Journal of Pharma Medicine and Biological Sciences	1	0	0	0	1	0.0	international-journal-of-pharma-medicine-and-biological-sciences
+International Journal of Pharmacy and Pharmaceutical Sciences	1	0	316	0	316	0.0	international-journal-of-pharmacy-and-pharmaceutical-sciences
+International Leprosy Association	1	0	0	0	134	0.0	international-leprosy-association
+International Life Sciences Institute	1	241	0	0	260	0.926923076923077	international-life-sciences-institute
+International Linear Algebra Society	1	2	0	869	869	0.0023014959723820483	international-linear-algebra-society
+International Measurement Confederation (IMECO)	1	0	0	226	226	0.0	international-measurement-confederation-imeco
+International Medical Press	1	31	0	1073	1073	0.028890959925442685	international-medical-press
+International Microelectronics And Packaging Society	1	53	0	363	363	0.14600550964187328	international-microelectronics-and-packaging-society
+International Microwave Power Institute	1	88	0	0	727	0.12104539202200826	international-microwave-power-institute
+International Monetary Fund	3	1157	0	210	1367	0.8463789319678128	international-monetary-fund
+International Mycological Association	1	156	175	175	175	0.8914285714285715	international-mycological-association
+International Network for the History of Public Health	1	1	126	126	126	0.007936507936507936	international-network-for-the-history-of-public-health
+International OCSCO World Press	1	0	47	47	47	0.0	international-ocsco-world-press
+International Organization for Biological Control	1	2005	0	0	2005	1.0	international-organization-for-biological-control
+International Press	1	87	549	549	549	0.15846994535519127	international-press
+International Press of Boston, Inc.	12	1289	211	9883	9883	0.13042598401295152	international-press-of-boston-inc
+International Research and Training Center on Erosion and Sedimentation and China Water and Power Press	1	139	0	146	146	0.952054794520548	international-research-and-training-center-on-erosion-and-sedimentation-and-china-water-and-power-press
+International Rhinologic Society	1	0	0	182	182	0.0	international-rhinologic-society
+International Scientific Information, Inc.	2	3	652	652	652	0.004601226993865031	international-scientific-information-inc
+International Scientific Literature, Inc	3	9	915	1064	1064	0.008458646616541353	international-scientific-literature-inc
+International Scientific Research Publications	1	0	111	0	111	0.0	international-scientific-research-publications
+International Seed Testing Association	1	933	0	1011	1011	0.9228486646884273	international-seed-testing-association
+International Society for Environmental Information Sciences	1	10	0	318	318	0.031446540880503145	international-society-for-environmental-information-sciences
+International Society for Gerontechnology	1	0	0	2389	2389	0.0	international-society-for-gerontechnology
+International Society for Horticultural Science	1	12065	0	62838	62838	0.19200165504949235	international-society-for-horticultural-science
+International Society of Histology and Cytology/Kokusai Soshiki Saibou Gakkai	1	1351	0	1405	1405	0.9615658362989323	international-society-of-histology-and-cytology-kokusai-soshiki-saibou-gakkai
+International Society of Offshore and Polar Engineers	2	0	0	110	110	0.0	international-society-of-offshore-and-polar-engineers
+International Society of Pteridinology	1	193	0	615	615	0.31382113821138213	international-society-of-pteridinology
+International Society on Aging and Disease	1	57	176	176	176	0.32386363636363635	international-society-on-aging-and-disease
+International Society on Hypertension in Blacks	1	0	0	120	120	0.0	international-society-on-hypertension-in-blacks
+International Union Against Tuberculosis And Lung Disease/Union Internationale Contre la Tuberculose et les Maladies Respiratories	1	1816	0	1979	1979	0.9176351692774128	international-union-against-tuberculosis-and-lung-disease-union-internationale-contre-la-tuberculose-et-les-maladies-respiratories
+International Union for Health Promotion & Education	1	1287	0	0	1287	1.0	international-union-for-health-promotion-education
+International Union of Crystallography	5	39110	42526	42526	68999	0.5668198089827389	international-union-of-crystallography
+International Union of Geological Sciences	1	0	0	77	77	0.0	international-union-of-geological-sciences
+International Universities Press	1	0	0	0	28	0.0	international-universities-press
+International Wader Study Group	1	0	0	55	55	0.0	international-wader-study-group
+International Water Association Publishing	2	621	0	762	762	0.8149606299212598	international-water-association-publishing
+Internet Journals, Inc.	1	2	0	0	2	1.0	internet-journals-inc
+Internet Medical Publishing	3	0	0	54	82	0.0	internet-medical-publishing
+Internet Scientific Publications	21	0	0	381	3652	0.0	internet-scientific-publications
+Interregional public organization Association of infectious disease specialists of Saint-Petersburg and Leningrad region (IPO AIDSSPbR)	1	0	15	15	15	0.0	interregional-public-organization-association-of-infectious-disease-specialists-of-saint-petersburg-and-leningrad-region-ipo-aidsspbr
+Interscience Publishers	4	7284	0	0	7876	0.9248349415947181	interscience-publishers
+IOS Press	76	12835	0	24549	24878	0.5159176782699574	ios-press
+IPC Science & Technology Press	4	2390	0	0	2390	1.0	ipc-science-technology-press
+IPEC Inc.	1	128	2092	2092	2092	0.06118546845124283	ipec-inc
+IPrA Research Center	1	1	0	599	599	0.001669449081803005	ipra-research-center
+Iranian Society of Ophthalmology	1	103	0	118	118	0.8728813559322034	iranian-society-of-ophthalmology
+Iranian Statistical Society	1	0	0	12	12	0.0	iranian-statistical-society
+Irish University Press for the Catholic Record Society of Ireland	1	308	0	308	308	1.0	irish-university-press-for-the-catholic-record-society-of-ireland
+ISCE Publishing	1	8	0	238	238	0.03361344537815126	isce-publishing
+ISCTE-IUL	1	0	0	159	159	0.0	iscte-iul
+ISEKI Food Association	1	0	100	100	100	0.0	iseki-food-association
+Isfahan University of Medical Sciences	4	33	884	892	892	0.03699551569506727	isfahan-university-of-medical-sciences
+Isfahan University of Technology	1	0	81	81	81	0.0	isfahan-university-of-technology
+Isis Medical Media Ltd.	3	0	0	0	60	0.0	isis-medical-media-ltd
+Islamic Azad University of Research and Technology	1	1790	0	1813	1813	0.9873138444567016	islamic-azad-university-of-research-and-technology
+Islamic Cultural Centre	1	0	0	1	1	0.0	islamic-cultural-centre
+Istanbul Technical University	1	65	0	0	70	0.9285714285714286	istanbul-technical-university
+Istanbul Teknik Universitesi, Faculty of Architecture	1	0	0	48	48	0.0	istanbul-teknik-universitesi-faculty-of-architecture
+Istanbul University	1	0	102	102	102	0.0	istanbul-university
+Istituti Editoriali e Poligrafici Internazionali	2	3618	0	3698	3698	0.9783666846944294	istituti-editoriali-e-poligrafici-internazionali
+Istituto di Geologia Applicata	1	187	0	0	187	1.0	istituto-di-geologia-applicata
+Istituto di Urologia	1	0	327	327	327	0.0	istituto-di-urologia
+Istituto Superiore di Sanita	1	2	71	71	71	0.028169014084507043	istituto-superiore-di-sanita
+IU School of Dentistry	1	1529	0	1548	1548	0.9877260981912145	iu-school-of-dentistry
+Iuliu Hatieganu Medical Publishing House	1	102	0	376	376	0.2712765957446808	iuliu-hatieganu-medical-publishing-house
+Ivanovo State University	1	0	0	72	72	0.0	ivanovo-state-university
+Ivanovo State University of Chemistry and Technology	1	14	0	413	413	0.03389830508474576	ivanovo-state-university-of-chemistry-and-technology
+Ivanovskaya Gosudarstvennaya Tekstil ' naya Akademiya	1	0	0	1	1	0.0	ivanovskaya-gosudarstvennaya-tekstil-naya-akademiya
+Ivyspring International Publisher	4	186	3945	3945	3945	0.04714828897338403	ivyspring-international-publisher
+IWA Publishing	10	14740	0	17644	17644	0.8354114713216958	iwa-publishing
+Izdatel'sto Radekon	1	0	0	0	10	0.0	izdatelsto-radekon
+Izdatel'stva Nauka	37	1475	0	4882	23524	0.06270192144193164	izdatelstva-nauka
+Izdatel'stvo Leningradskogo Universiteta	1	0	0	0	40	0.0	izdatelstvo-leningradskogo-universiteta
+Izdatel'stvo Meditsina	1	0	0	92	92	0.0	izdatelstvo-meditsina
+Izdatel'stvo Meditsina Publishers	5	0	0	953	953	0.0	izdatelstvo-meditsina-publishers
+Izdatel'stvo Sibirskoe Otdelenie Rossiiskoi Akademii Nauk	1	0	0	0	102	0.0	izdatelstvo-sibirskoe-otdelenie-rossiiskoi-akademii-nauk
+Izdatel'stvo Sibirskogo Otdeleniia RAN	1	0	0	34	34	0.0	izdatelstvo-sibirskogo-otdeleniia-ran
+Izdatel'stvo Sibirskogo Otdeleniya Rossiiskoi Akademii Nauk/Publishing House of the Russian Academy of Sciences	2	0	0	0	579	0.0	izdatelstvo-sibirskogo-otdeleniya-rossiiskoi-akademii-nauk-publishing-house-of-the-russian-academy-of-sciences
+Izdatelstvo Krasnaia Zvezda	1	0	0	2	2	0.0	izdatelstvo-krasnaia-zvezda
+Izdvo InfoMedia	1	0	0	2	2	0.0	izdvo-infomedia
+Iziko Museums	1	0	3	3	3	0.0	iziko-museums
+J O M Institute	1	9356	0	10825	10825	0.8642956120092379	j-o-m-institute
+J. Van Voorst	1	6267	0	0	8022	0.781226626776365	j-van-voorst
+J.B. Metzlersche Verlagsbuchhandlung	1	98	0	1970	1970	0.049746192893401014	j-b-metzlersche-verlagsbuchhandlung
+J.C.B.Mohr	1	14	0	0	14	1.0	j-c-b-mohr
+J.F. Bergmann	3	13729	0	0	13729	1.0	j-f-bergmann
+J.Michael Ryan Publishing Inc.	1	97	0	120	120	0.8083333333333333	j-michael-ryan-publishing-inc
+J.R. Prous	1	1	0	0	557	0.0017953321364452424	j-r-prous
+Jagiellonian University Press	3	902	0	2055	2055	0.4389294403892944	jagiellonian-university-press
+James Nicholas Publishers, Pty. Ltd	2	539	0	628	628	0.85828025477707	james-nicholas-publishers-pty-ltd
+Japan Association for Wind Engineering	1	0	0	155	155	0.0	japan-association-for-wind-engineering
+Japan Association of Solvent Extraction	1	1	0	156	156	0.00641025641025641	japan-association-of-solvent-extraction
+Japan Atherosclerosis Society	1	1	1673	1673	1673	5.977286312014345e-4	japan-atherosclerosis-society
+Japan Concrete Institute/Nihon Konkurito Kogaku Kyokai	1	0	0	545	545	0.0	japan-concrete-institute-nihon-konkurito-kogaku-kyokai
+Japan Endocrine Sociey/Nihon Naibunpi Gakkai	1	3129	3178	3178	3178	0.9845814977973568	japan-endocrine-sociey-nihon-naibunpi-gakkai
+Japan Institute Of Energy	1	0	0	1051	1051	0.0	japan-institute-of-energy
+Japan Institute of Metals	2	9215	0	7466	9750	0.9451282051282052	japan-institute-of-metals
+Japan Laser Processing	1	22	585	585	585	0.037606837606837605	japan-laser-processing
+Japan Mendel Society	1	5023	0	5209	5209	0.9642925705509695	japan-mendel-society
+Japan Meteorological Agency	1	0	0	990	990	0.0	japan-meteorological-agency
+Japan Neurosurgical Society/Nihon No Shinkei Geka Gakkai	1	7733	7792	7792	7792	0.9924281314168378	japan-neurosurgical-society-nihon-no-shinkei-geka-gakkai
+Japan Oil Chemists Society	1	150	0	1675	1675	0.08955223880597014	japan-oil-chemists-society
+Japan Petroleum Institute	1	48	745	745	745	0.06442953020134229	japan-petroleum-institute
+Japan Poultry Science Association	1	0	799	799	799	0.0	japan-poultry-science-association
+Japan Radioisotope Association	1	0	0	0	6549	0.0	japan-radioisotope-association
+Japan Science Society of Biological Macromolecules	1	0	0	2	2	0.0	japan-science-society-of-biological-macromolecules
+Japan Scientific Societies Press	1	303	0	0	340	0.8911764705882353	japan-scientific-societies-press
+Japan Soc of Applied Physics	1	3100	0	3767	3767	0.8229360233607645	japan-soc-of-applied-physics
+Japan Society for Analytical Chemistry	4	21572	8104	21030	21704	0.9939181717655732	japan-society-for-analytical-chemistry
+Japan Society for Bioscience Biotechnology and Agrochemistry	1	989	0	0	2135	0.463231850117096	japan-society-for-bioscience-biotechnology-and-agrochemistry
+Japan Society for Bioscience Biotechnology and Agrochemistry/Nippon Nogeikagaku Kai	2	13355	0	0	37974	0.3516879970506136	japan-society-for-bioscience-biotechnology-and-agrochemistry-nippon-nogeikagaku-kai
+Japan Society for Cell Biology	1	1	1615	1615	1615	6.191950464396285e-4	japan-society-for-cell-biology
+Japan Society for Clinical Immunology	1	0	0	3840	3840	0.0	japan-society-for-clinical-immunology
+Japan Society for Occupational Health/Nihon Sangyo Eisei Gakkai	2	89	1350	1350	3962	0.022463402322059567	japan-society-for-occupational-health-nihon-sangyo-eisei-gakkai
+Japan Society of Applied Physics	3	191841	0	148120	222180	0.8634485552254928	japan-society-of-applied-physics
+Japan Society of Atmospheric Environment	1	1	0	198	198	0.005050505050505051	japan-society-of-atmospheric-environment
+Japan Society of Civil Engineers	1	9	0	0	372	0.024193548387096774	japan-society-of-civil-engineers
+Japan Society of Civil Engineers/Doboku Gakkai	1	8	0	0	137	0.058394160583941604	japan-society-of-civil-engineers-doboku-gakkai
+Japan Society of Drug Delivery System	1	0	0	1343	1343	0.0	japan-society-of-drug-delivery-system
+Japan Society of High Pressure Science and Technology	1	1	0	1442	1442	6.934812760055479e-4	japan-society-of-high-pressure-science-and-technology
+Japan Society of Histochemistry and Cytochemistry	1	2264	2371	2371	2371	0.9548713622943905	japan-society-of-histochemistry-and-cytochemistry
+Japan Society of Logopedics and Phoniatrics	1	0	0	1491	1491	0.0	japan-society-of-logopedics-and-phoniatrics
+Japan Society of Magnetic Resonance in Medicine	1	24	0	587	587	0.04088586030664395	japan-society-of-magnetic-resonance-in-medicine
+Japan Society of Mechanical Engineers	1	822	0	839	839	0.9797377830750894	japan-society-of-mechanical-engineers
+Japan Society of Mechanical Engineers/Nihon Kikai Gakkai	11	44120	0	872	44235	0.9974002486718662	japan-society-of-mechanical-engineers-nihon-kikai-gakkai
+Japan Society of Physiological Anthropology	2	43	0	0	471	0.09129511677282377	japan-society-of-physiological-anthropology
+Japan TAAPI	1	0	0	0	9199	0.0	japan-taapi
+Japan Welding Society/Yosetsu Gakkai	2	0	0	8724	8724	0.0	japan-welding-society-yosetsu-gakkai
+Japan Wood Research Society	1	0	0	0	473	0.0	japan-wood-research-society
+Japanese Association for Laboratory Animal Science	1	1169	1201	1201	1201	0.9733555370524563	japanese-association-for-laboratory-animal-science
+Japanese Association for Oral Biology	1	465	0	739	739	0.6292286874154263	japanese-association-for-oral-biology
+Japanese Association of Education Psychology	1	0	0	2679	2679	0.0	japanese-association-of-education-psychology
+Japanese Association of Mineralogists Petrologists and Economic Geologists	2	0	0	636	1230	0.0	japanese-association-of-mineralogists-petrologists-and-economic-geologists
+Japanese Circulation Society/Nihon Junkanki Gakkai	2	11433	6132	6132	11624	0.9835684790089471	japanese-circulation-society-nihon-junkanki-gakkai
+Japanese Coloproctological Association	1	0	0	0	4281	0.0	japanese-coloproctological-association
+Japanese Geotechnical Society	1	596	0	1175	1175	0.5072340425531915	japanese-geotechnical-society
+Japanese Leprosy Association/Nihon Rai Gakukai	2	0	0	290	637	0.0	japanese-leprosy-association-nihon-rai-gakukai
+Japanese Pharmacological Society	1	6059	0	0	6105	0.9924651924651925	japanese-pharmacological-society
+Japanese Physical Therapy Association	1	0	0	167	167	0.0	japanese-physical-therapy-association
+Japanese Psychological Association	1	1	0	4023	4023	2.4857071836937607e-4	japanese-psychological-association
+Japanese Society for Food and Technology	1	2449	0	2593	2593	0.9444658696490551	japanese-society-for-food-and-technology
+Japanese Society for Horticultural Science	2	89	0	150	4798	0.018549395581492288	japanese-society-for-horticultural-science
+Japanese Society for Hygiene	1	2415	0	2432	2432	0.9930098684210527	japanese-society-for-hygiene
+Japanese Society for Infection Prevention and Control	1	0	0	0	469	0.0	japanese-society-for-infection-prevention-and-control
+Japanese Society for Medical Mycology	1	1069	0	1091	1091	0.9798350137488543	japanese-society-for-medical-mycology
+Japanese Society for Pediatric Endocrinology	1	0	720	720	720	0.0	japanese-society-for-pediatric-endocrinology
+Japanese Society for Root Research	1	15	88	88	88	0.17045454545454544	japanese-society-for-root-research
+Japanese Society of Agricultural, Biological and Environmental Engineers and Scientists (JASBEES)	1	0	0	376	376	0.0	japanese-society-of-agricultural-biological-and-environmental-engineers-and-scientists-jasbees
+Japanese Society of Applied Entomology and Zoology	1	2754	0	2796	2796	0.9849785407725322	japanese-society-of-applied-entomology-and-zoology
+Japanese Society of Breeding	1	304	1091	1091	1091	0.27864344637946836	japanese-society-of-breeding
+Japanese Society Of Developmental Biologists	1	199	0	0	199	1.0	japanese-society-of-developmental-biologists
+Japanese Society of Environment Control in Biology	1	0	0	0	1077	0.0	japanese-society-of-environment-control-in-biology
+Japanese Society of Equine Science	1	333	346	346	346	0.9624277456647399	japanese-society-of-equine-science
+Japanese Society of Fish Pathalogy	1	0	0	1716	1716	0.0	japanese-society-of-fish-pathalogy
+Japanese Society of Hard Tissue Research & Technology	1	0	0	696	696	0.0	japanese-society-of-hard-tissue-research-technology
+Japanese Society of Hepatology	1	1	0	8497	8497	1.1768859597505002e-4	japanese-society-of-hepatology
+Japanese Society of Internal Medicine/Nihon Naika Gakkai	3	28678	10237	27741	29294	0.9789718030996108	japanese-society-of-internal-medicine-nihon-naika-gakkai
+Japanese Society of Limnology	1	0	0	1776	1776	0.0	japanese-society-of-limnology
+Japanese Society of Mammalian Ova Research	1	331	0	616	616	0.5373376623376623	japanese-society-of-mammalian-ova-research
+Japanese Society Of Microbial Ecology	1	928	0	943	943	0.9840933191940615	japanese-society-of-microbial-ecology
+Japanese Society of Neurology/Nihon Shinkei Gakkai	1	1919	0	2133	2133	0.8996718237224567	japanese-society-of-neurology-nihon-shinkei-gakkai
+Japanese Society of Physical Fitness and Sports Medicine	1	0	0	4053	4053	0.0	japanese-society-of-physical-fitness-and-sports-medicine
+Japanese Society of Plant Cell and Molecular Biology	1	5	1347	1347	1347	0.003711952487008166	japanese-society-of-plant-cell-and-molecular-biology
+Japanese Society of Scientific Fisheries	1	14257	0	14925	14925	0.9552428810720268	japanese-society-of-scientific-fisheries
+Japanese Society of Smooth Muscle Research	1	0	474	474	474	0.0	japanese-society-of-smooth-muscle-research
+Japanese Society of Snow and Ice	1	0	0	33	33	0.0	japanese-society-of-snow-and-ice
+Japanese Society of Systematic Zoology	1	0	0	115	115	0.0	japanese-society-of-systematic-zoology
+Japanese Society of Toxicological Sciences	1	2446	2493	2493	2493	0.9811472121941436	japanese-society-of-toxicological-sciences
+Japanese Urological Association	1	0	0	2502	2502	0.0	japanese-urological-association
+Jardin Botanique National de Belgique/Nationale Plantentuin van Belgie	1	169	0	0	169	1.0	jardin-botanique-national-de-belgique-nationale-plantentuin-van-belgie
+Jaypee Brothers Medical Publishers (P) Ltd	10	654	0	2582	2642	0.24753974261922787	jaypee-brothers-medical-publishers-p-ltd
+JBC Pub. Co.	1	4239	0	0	4345	0.9756041426927503	jbc-pub-co
+JCDR Research and Publications (Pvt) Limited	1	1	3	3	3	0.3333333333333333	jcdr-research-and-publications-pvt-limited
+JEMS Communications	2	0	0	1059	1144	0.0	jems-communications
+Jems Pub. Co.	1	540	0	0	540	1.0	jems-pub-co
+Jeoloji Mühendisligi	1	0	0	25	25	0.0	jeoloji-muhendisligi
+Jinko Chino Gakkai	1	0	0	967	967	0.0	jinko-chino-gakkai
+Joanna Briggs Institute	1	2	0	1646	1646	0.001215066828675577	joanna-briggs-institute
+Johann Ambrosius Barth	4	853	0	308	1161	0.7347114556416882	johann-ambrosius-barth
+John Benjamins Publishing Company	50	21016	0	24291	24391	0.8616292894920258	john-benjamins-publishing-company
+John Jay Press	1	0	0	0	27	0.0	john-jay-press
+Johns Hopkins University Press	54	84674	0	135224	135224	0.6261758267763119	johns-hopkins-university-press
+Johnson Matthey PLC	1	464	0	0	494	0.9392712550607287	johnson-matthey-plc
+Johnson Matthey Public Limited Company	1	89	124	124	124	0.717741935483871	johnson-matthey-public-limited-company
+Joint Commission Resources Inc.	2	1438	0	1250	1452	0.990358126721763	joint-commission-resources-inc
+Jordan University of Science and Technology	1	0	0	61	61	0.0	jordan-university-of-science-and-technology
+Jossey-Bass Inc.	1	985	0	0	996	0.9889558232931727	jossey-bass-inc
+Journal of Ayn Rand Studies Foundation	1	69	0	74	74	0.9324324324324325	journal-of-ayn-rand-studies-foundation
+Journal of Bone and Joint Surgery Inc.	1	181	0	192	192	0.9427083333333334	journal-of-bone-and-joint-surgery-inc
+Journal of Language Contact Publishers	1	197	0	241	241	0.8174273858921162	journal-of-language-contact-publishers
+Journal of medical Internet Research	1	5	2192	2192	2192	0.002281021897810219	journal-of-medical-internet-research
+Journal of New Materials for Electrochemical Systems	1	0	0	9	9	0.0	journal-of-new-materials-for-electrochemical-systems
+Journal of Pharmaceutical Research and Health Care	1	0	52	0	52	0.0	journal-of-pharmaceutical-research-and-health-care
+Journal of Rheumatology Publishing Co., Ltd.	2	3984	0	4052	4052	0.983218163869694	journal-of-rheumatology-publishing-co-ltd
+Journal of Social, Evolutionary, and Cultural Psychology	1	4	0	0	194	0.020618556701030927	journal-of-social-evolutionary-and-cultural-psychology
+Journal of Studies on Alcohol Inc.	3	694	0	0	3773	0.1839385104691227	journal-of-studies-on-alcohol-inc
+Journal of Technology Management & Innovation Group	1	2	552	552	552	0.0036231884057971015	journal-of-technology-management-innovation-group
+Journal of the Society for the Advancement of Scandinavian Study	1	130	0	184	184	0.7065217391304348	journal-of-the-society-for-the-advancement-of-scandinavian-study
+Journal of traditional chinese medicine	1	852	0	0	891	0.9562289562289562	journal-of-traditional-chinese-medicine
+JSC Znack	1	0	0	0	23	0.0	jsc-znack
+Jugoslovensko udruzenje za sociologiju	1	3	363	363	363	0.008264462809917356	jugoslovensko-udruzenje-za-sociologiju
+Juliusz Schauder Center	1	6	0	589	589	0.010186757215619695	juliusz-schauder-center
+Junk Publishers	1	415	0	0	415	1.0	junk-publishers
+Just Medical Media Ltd	1	3	100	100	100	0.03	just-medical-media-ltd
+K.G. Saur Verlag	2	1530	577	577	2117	0.7227208313651393	k-g-saur-verlag
+Kafkas University	1	419	1720	1720	1720	0.2436046511627907	kafkas-university
+Kalasalingam University	1	79	88	88	88	0.8977272727272727	kalasalingam-university
+Kansas Entomological Society	1	619	0	623	623	0.9935794542536116	kansas-entomological-society
+KARE Publishing	1	84	587	587	587	0.14310051107325383	kare-publishing
+Karger	156	119263	10957	308494	334338	0.35671386441266023	karger
+Karl F. Haug Verlag in MVS Medizinverlage Stuttgart GmbH & Co. KG	2	896	0	477	954	0.939203354297694	karl-f-haug-verlag-in-mvs-medizinverlage-stuttgart-gmbh-co-kg
+Kashihara Nihon Heikatsukin Gakkai	1	0	0	0	507	0.0	kashihara-nihon-heikatsukin-gakkai
+Kassel University Press GmbH	3	8	0	1821	1821	0.004393190554640308	kassel-university-press-gmbh
+Kathmandu University	1	0	0	631	631	0.0	kathmandu-university
+Katholieke Universiteit, Instituut voor Culturele en Sociale Antropologie, University Of Nijmegen	1	261	0	386	386	0.6761658031088082	katholieke-universiteit-instituut-voor-culturele-en-sociale-antropologie-university-of-nijmegen
+Katolicki Uniwersytet Lubelski Jana Pawla II	1	0	0	102	102	0.0	katolicki-uniwersytet-lubelski-jana-pawla-ii
+Kaunas University of Technology	6	437	550	2064	2064	0.21172480620155038	kaunas-university-of-technology
+Kauno Medicinos Universitetas	1	181	188	188	188	0.9627659574468085	kauno-medicinos-universitetas
+Kauno Technologijos Universitetas	1	1	0	1197	1197	8.35421888053467e-4	kauno-technologijos-universitetas
+KeAi Communications Co	4	463	0	523	523	0.8852772466539197	keai-communications-co
+Keikinzoku Gakkai/Japan Institute of Light Metals	1	5440	0	5550	5550	0.9801801801801802	keikinzoku-gakkai-japan-institute-of-light-metals
+Keimyung University, Academia Koreana	1	0	0	175	175	0.0	keimyung-university-academia-koreana
+Keio Gijuku Daigaku	1	0	0	1590	1590	0.0	keio-gijuku-daigaku
+Kemerovo Technological Institute of Food Industry (University)	1	0	0	143	143	0.0	kemerovo-technological-institute-of-food-industry-university
+Ken-yusha, Inc.	1	0	0	670	670	0.0	ken-yusha-inc
+Kent State University	2	198	0	4974	4974	0.039806996381182146	kent-state-university
+Kenya Medical Association	1	2	0	1311	1311	0.0015255530129672007	kenya-medical-association
+Kerala Forest Research Institute	1	168	0	0	168	1.0	kerala-forest-research-institute
+Kerman University of Medical Science	1	4	542	542	542	0.007380073800738007	kerman-university-of-medical-science
+Kermanshah University of Medical Sciences	1	1	140	140	140	0.007142857142857143	kermanshah-university-of-medical-sciences
+Kern und Birner GmbH and Co.	1	1530	0	0	1971	0.776255707762557	kern-und-birner-gmbh-and-co
+Kiadja Es Terjeszti A Literatura Medica	1	0	0	106	106	0.0	kiadja-es-terjeszti-a-literatura-medica
+Kiel Institute for the World Economy	1	8	363	363	363	0.02203856749311295	kiel-institute-for-the-world-economy
+Kiepert	1	0	0	0	449	0.0	kiepert
+Kim Williams	1	629	0	638	638	0.9858934169278997	kim-williams
+King Abdulaziz University Scientific Publishing Center	3	1	0	628	887	0.0011273957158962795	king-abdulaziz-university-scientific-publishing-center
+King Faisal Specialist Hospital and Research Centre	1	403	0	441	441	0.9138321995464853	king-faisal-specialist-hospital-and-research-centre
+King Saud University	11	7598	7226	7755	7755	0.9797549967762734	king-saud-university
+Kinokuniya Co., Ltd.	1	160	0	0	160	1.0	kinokuniya-co-ltd
+Kitakanto Medical Society	1	0	0	1622	1622	0.0	kitakanto-medical-society
+Klinicka Bolnica Sestre Milosrdnice	2	0	73	90	90	0.0	klinicka-bolnica-sestre-milosrdnice
+Klinika za Djecje Bolesti Zagerb/Children's Hospital in Zagreb	1	0	0	64	64	0.0	klinika-za-djecje-bolesti-zagerb-childrens-hospital-in-zagreb
+KMK Scientific Press Ltd.	1	0	0	5	5	0.0	kmk-scientific-press-ltd
+Kobunshi Kagaku	1	4538	0	4882	4882	0.9295370749692748	kobunshi-kagaku
+Kokubyo Gakkai	1	0	0	3151	3151	0.0	kokubyo-gakkai
+Kolej Universiti Islam Sultan Azlan Shah	1	0	90	90	90	0.0	kolej-universiti-islam-sultan-azlan-shah
+Kommissionsverlag F. Steiner	1	30	0	52	52	0.5769230769230769	kommissionsverlag-f-steiner
+Koninklijke Van Gorcum BV	3	817	0	891	891	0.9169472502805837	koninklijke-van-gorcum-bv
+Konkoly Observatory	1	0	15	15	15	0.0	konkoly-observatory
+Konrad Lorenz Fundacion Universitaria	1	64	68	68	68	0.9411764705882353	konrad-lorenz-fundacion-universitaria
+Korea Advanced Institute of Science and Technology	1	19	0	2927	2927	0.006491288008199521	korea-advanced-institute-of-science-and-technology
+Korea Distribution Science Association (KODISA)	1	0	0	798	798	0.0	korea-distribution-science-association-kodisa
+Korea Health Personnel Licensing Examination Institute	1	2	211	211	211	0.009478672985781991	korea-health-personnel-licensing-examination-institute
+Korea Information Processing Society (KIPS)	1	2	0	343	343	0.0058309037900874635	korea-information-processing-society-kips
+Korea Institute for Defense Analyses	1	410	0	749	749	0.5473965287049399	korea-institute-for-defense-analyses
+Korea Institute of Applied Superconductivity and Cryogenics	1	4	0	250	250	0.016	korea-institute-of-applied-superconductivity-and-cryogenics
+Korea Ocean Research and Development Institute	2	426	658	1105	1105	0.38552036199095024	korea-ocean-research-and-development-institute
+Korea Soc of Automotive Engineers, Inc	1	1002	0	1002	1002	1.0	korea-soc-of-automotive-engineers-inc
+Korea Society of Internet Information	1	7	0	1611	1611	0.004345127250155183	korea-society-of-internet-information
+Korean Academy of Child Health Nursing	1	0	0	163	163	0.0	korean-academy-of-child-health-nursing
+Korean Academy of Family Medicine	1	2	0	546	546	0.003663003663003663	korean-academy-of-family-medicine
+Korean Academy of Medical Sciences	1	30	5295	5295	5295	0.0056657223796034	korean-academy-of-medical-sciences
+Korean Academy of Oral and Maxillofacial Radiology	1	4	265	265	265	0.01509433962264151	korean-academy-of-oral-and-maxillofacial-radiology
+Korean Academy of Orthodonics	1	6	0	412	412	0.014563106796116505	korean-academy-of-orthodonics
+Korean Academy of Periodontology	1	9	331	331	331	0.027190332326283987	korean-academy-of-periodontology
+Korean Academy of Rehabilitation Medicine (KARM)	1	10	803	803	803	0.012453300124533	korean-academy-of-rehabilitation-medicine-karm
+Korean Association for the Study of Intestinal Diseases	1	2	0	386	386	0.0051813471502590676	korean-association-for-the-study-of-intestinal-diseases
+Korean Association for the Study of the Liver	2	5	276	276	556	0.008992805755395683	korean-association-for-the-study-of-the-liver
+Korean Association of Anatomists	1	0	216	216	216	0.0	korean-association-of-anatomists
+Korean Association of Immunologists	1	5	0	578	578	0.00865051903114187	korean-association-of-immunologists
+Korean Association of Medical Journal Edirors	3	5	0	942	942	0.005307855626326964	korean-association-of-medical-journal-edirors
+Korean Audiological Society	2	2	0	67	163	0.012269938650306749	korean-audiological-society
+Korean Biodiversity Information Facility	1	220	257	257	257	0.8560311284046692	korean-biodiversity-information-facility
+Korean Breast Cancer Society	1	5	0	712	712	0.007022471910112359	korean-breast-cancer-society
+Korean Cancer Association	1	8	1126	1126	1126	0.007104795737122558	korean-cancer-association
+Korean Carbon Society	1	7	0	403	403	0.017369727047146403	korean-carbon-society
+Korean Ceramic Society	1	3	0	1943	1943	0.001544004117344313	korean-ceramic-society
+Korean Chemical Society	1	17	0	1412	1412	0.012039660056657223	korean-chemical-society
+Korean College of Neuropsychopharmacology	1	3	251	251	251	0.01195219123505976	korean-college-of-neuropsychopharmacology
+Korean Dermatological Association	1	17	2260	2260	2260	0.00752212389380531	korean-dermatological-association
+Korean Diabetes Association	1	16	475	475	475	0.03368421052631579	korean-diabetes-association
+Korean Endocrine Society	1	5	0	537	537	0.00931098696461825	korean-endocrine-society
+Korean Fiber Society	1	2491	0	2519	2519	0.9888844779674474	korean-fiber-society
+Korean Fluid Machinary Association	1	0	0	275	275	0.0	korean-fluid-machinary-association
+Korean Gastric Cancer Association	1	8	296	296	296	0.02702702702702703	korean-gastric-cancer-association
+Korean Institute of Communication Sciences	1	1651	0	1652	1652	0.9993946731234867	korean-institute-of-communication-sciences
+Korean Institute of Electrical Engineers	3	1288	0	4690	4690	0.2746268656716418	korean-institute-of-electrical-engineers
+Korean Institute of Industrial Engineers	1	2	0	269	269	0.007434944237918215	korean-institute-of-industrial-engineers
+Korean Institute of Information Scientists and Engineers	1	1	0	202	202	0.0049504950495049506	korean-institute-of-information-scientists-and-engineers
+Korean Institute of Metals and Materials	4	3277	0	3890	4265	0.7683470105509965	korean-institute-of-metals-and-materials
+Korean Institute of Power Electronics	1	101	0	988	988	0.10222672064777327	korean-institute-of-power-electronics
+Korean Journal of Veterinary Research	1	0	0	144	144	0.0	korean-journal-of-veterinary-research
+Korean Mathematical Society	2	12	0	2186	2186	0.0054894784995425435	korean-mathematical-society
+Korean Medical Association	1	4	0	1336	1336	0.0029940119760479044	korean-medical-association
+Korean Meteorological Society	1	310	0	324	324	0.9567901234567902	korean-meteorological-society
+Korean National Tuberculosis Association	1	5	1477	1477	1477	0.003385240352064997	korean-national-tuberculosis-association
+Korean Neurological Association	2	5	598	1400	1400	0.0035714285714285713	korean-neurological-association
+Korean Neuropsychiatric Association	1	4	619	619	619	0.006462035541195477	korean-neuropsychiatric-association
+Korean Orthopaedic Association	1	5	492	492	492	0.01016260162601626	korean-orthopaedic-association
+Korean Pediatric Society	1	13	1572	1572	1572	0.00826972010178117	korean-pediatric-society
+Korean Pharmacopuncture Institute	1	1	0	258	258	0.003875968992248062	korean-pharmacopuncture-institute
+Korean Physical Society	1	0	0	1375	1375	0.0	korean-physical-society
+Korean Radiological Society	1	11	1545	1545	1545	0.007119741100323625	korean-radiological-society
+Korean Society for Applied Microbiology	1	0	0	0	327	0.0	korean-society-for-applied-microbiology
+Korean Society for Biochemistry and Molecular Biology	1	11	1792	1792	1792	0.006138392857142857	korean-society-for-biochemistry-and-molecular-biology
+Korean Society for Biotechnology and Bioengineering	1	1988	0	2010	2010	0.9890547263681592	korean-society-for-biotechnology-and-bioengineering
+Korean Society for Brain and Neural Science	1	2	0	269	269	0.007434944237918215	korean-society-for-brain-and-neural-science
+Korean Society for Clinical Pharmacology and Therapeutics	2	1	75	75	109	0.009174311926605505	korean-society-for-clinical-pharmacology-and-therapeutics
+Korean Society for Food Science of Animal Resources	1	4	0	1049	1049	0.0038131553860819827	korean-society-for-food-science-of-animal-resources
+Korean Society for Horticultural Science	1	1	0	457	457	0.002188183807439825	korean-society-for-horticultural-science
+Korean Society for Laboratory Medicine	1	5	0	0	489	0.010224948875255624	korean-society-for-laboratory-medicine
+Korean Society for Microbiolog and Biotechnology	1	0	0	327	327	0.0	korean-society-for-microbiolog-and-biotechnology
+Korean Society for Microbiology/Taehan Misaengmul Hakhoe	1	1	0	424	424	0.0023584905660377358	korean-society-for-microbiology-taehan-misaengmul-hakhoe
+Korean Society for Parasitology	1	10	2110	2110	2110	0.004739336492890996	korean-society-for-parasitology
+Korean Society for Precision Engineeing	1	0	0	772	772	0.0	korean-society-for-precision-engineeing
+Korean Society for Reproductive Medicine	1	5	202	202	202	0.024752475247524754	korean-society-for-reproductive-medicine
+Korean Society for Stem Cell Research	1	2	0	193	193	0.010362694300518135	korean-society-for-stem-cell-research
+Korean Society for Therapeutic Radiology and Oncology	1	1	218	218	218	0.0045871559633027525	korean-society-for-therapeutic-radiology-and-oncology
+Korean Society for Thoracic and Cardiovascular Surgery	1	6	0	794	794	0.007556675062972292	korean-society-for-thoracic-and-cardiovascular-surgery
+Korean Society Mass Spectrometry	1	1	129	129	129	0.007751937984496124	korean-society-mass-spectrometry
+Korean Society of Anesthesiologists	1	715	0	1764	1764	0.40532879818594103	korean-society-of-anesthesiologists
+Korean Society of Applied Pharmacology	1	19	0	770	770	0.024675324675324677	korean-society-of-applied-pharmacology
+Korean Society of Circulation	1	6	1573	1573	1573	0.003814367450731087	korean-society-of-circulation
+Korean Society of Coloproctology	2	2	267	267	526	0.0038022813688212928	korean-society-of-coloproctology
+Korean Society of Echocardiography	1	3	407	407	407	0.007371007371007371	korean-society-of-echocardiography
+Korean Society of Electrolyte & Blood Pressure Research	1	2	0	132	132	0.015151515151515152	korean-society-of-electrolyte-blood-pressure-research
+Korean Society of Environmental Engineers	1	3	0	552	552	0.005434782608695652	korean-society-of-environmental-engineers
+Korean Society of Environmental Risk Assessment and Health Science	1	284	0	295	295	0.9627118644067797	korean-society-of-environmental-risk-assessment-and-health-science
+Korean Society of Epidemiology	1	3	0	225	225	0.013333333333333334	korean-society-of-epidemiology
+Korean Society of Food Science and Nutrition	3	19	0	4562	4563	0.0041639272408503175	korean-society-of-food-science-and-nutrition
+Korean Society of Food Science and Technology	1	1857	0	1902	1902	0.9763406940063092	korean-society-of-food-science-and-technology
+Korean Society of Gastroenterology	1	13	0	1111	1111	0.011701170117011701	korean-society-of-gastroenterology
+Korean Society of Gastrointestinal Endoscopy	1	7	638	638	638	0.0109717868338558	korean-society-of-gastrointestinal-endoscopy
+Korean Society of Gynecologic Oncology and Colposcopy	1	5	566	566	566	0.0088339222614841	korean-society-of-gynecologic-oncology-and-colposcopy
+Korean Society of Hematology	2	2	271	271	725	0.002758620689655172	korean-society-of-hematology
+Korean Society of Industrial Engineering Chemistry	2	3369	0	3749	3749	0.8986396372365965	korean-society-of-industrial-engineering-chemistry
+Korean Society of Mechanical Engineers	5	6498	0	10375	11974	0.542675797561383	korean-society-of-mechanical-engineers
+Korean Society of Medical Education	1	1	0	866	866	0.0011547344110854503	korean-society-of-medical-education
+Korean Society of Medical Informatics	1	3	317	317	317	0.00946372239747634	korean-society-of-medical-informatics
+Korean Society of Mycology	1	224	789	789	789	0.28390367553865653	korean-society-of-mycology
+Korean Society of Neurogastroenterology and Motility	1	6	722	722	722	0.008310249307479225	korean-society-of-neurogastroenterology-and-motility
+Korean Society of Nursing Science	1	12	0	756	756	0.015873015873015872	korean-society-of-nursing-science
+Korean Society of Otorhinolaryngology	1	5	529	529	529	0.00945179584120983	korean-society-of-otorhinolaryngology
+Korean Society of Pathologists	2	232	193	193	825	0.2812121212121212	korean-society-of-pathologists
+Korean Society of Pediartic Gastroenterology, Hepatology and Nutrition	1	3	0	232	232	0.01293103448275862	korean-society-of-pediartic-gastroenterology-hepatology-and-nutrition
+Korean Society of Pediatric Infectious Diseases	2	0	88	61	88	0.0	korean-society-of-pediatric-infectious-diseases
+Korean Society of Pharmacognosy	1	0	0	63	63	0.0	korean-society-of-pharmacognosy
+Korean Society of Plant Biotechnology	1	0	470	470	470	0.0	korean-society-of-plant-biotechnology
+Korean Society of Plastic and Reconstructive Surgeons	1	10	817	817	817	0.012239902080783354	korean-society-of-plastic-and-reconstructive-surgeons
+Korean Society of Spine Surgery	1	7	722	722	722	0.009695290858725761	korean-society-of-spine-surgery
+Korean Society of Steel Construction	1	481	0	518	518	0.9285714285714286	korean-society-of-steel-construction
+Korean Society of Surveying, Geodesy, Photogrammetry and Cartography	1	0	0	400	400	0.0	korean-society-of-surveying-geodesy-photogrammetry-and-cartography
+Korean Society of Veterinary Clinics	1	0	324	324	324	0.0	korean-society-of-veterinary-clinics
+Korean Society of Veterinary Science	1	11	765	765	765	0.01437908496732026	korean-society-of-veterinary-science
+Korean Society Rheology	1	219	0	222	222	0.9864864864864865	korean-society-rheology
+Korean Stroke Society	1	4	0	174	174	0.022988505747126436	korean-stroke-society
+Korean Surgical Society	2	6	376	376	1013	0.005923000987166831	korean-surgical-society
+Korean Urological Association	2	287	114	1240	1240	0.2314516129032258	korean-urological-association
+Kossuth Lajos Tudomanyegyetem	1	9	0	475	475	0.018947368421052633	kossuth-lajos-tudomanyegyetem
+Kowsar	2	1	166	369	369	0.0027100271002710027	kowsar
+Kowsar Publishing Company	14	1170	4353	6679	6679	0.17517592453960174	kowsar-publishing-company
+Kozponti Statisztikai Hivatal	1	0	0	0	43	0.0	kozponti-statisztikai-hivatal
+Krm Information Services	1	3	0	0	109	0.027522935779816515	krm-information-services
+Kunming Institute of Zoology, Chinese Academy of Sciences	1	2	0	330	330	0.006060606060606061	kunming-institute-of-zoology-chinese-academy-of-sciences
+Kure Iletisim Grubu A S	1	0	0	36	36	0.0	kure-iletisim-grubu-a-s
+Kurume University School of Medicine	1	0	0	1878	1878	0.0	kurume-university-school-of-medicine
+Kuwait University	1	0	0	88	88	0.0	kuwait-university
+Kyoto Daigaku	1	12662	0	14368	14368	0.8812639198218263	kyoto-daigaku
+Kyoto University	2	1834	0	4175	4175	0.4392814371257485	kyoto-university
+Kyushu University	2	1	560	6795	6795	1.4716703458425313e-4	kyushu-university
+L & H Scientific Publishing, LLC	2	0	0	283	283	0.0	l-h-scientific-publishing-llc
+L and H Scientific Publishing, LLC	1	0	0	109	109	0.0	l-and-h-scientific-publishing-llc
+L'Esprit du Temps	4	6	0	1970	1971	0.0030441400304414	lesprit-du-temps
+L'Expansion Scientifique Francaise	1	760	0	0	760	1.0	lexpansion-scientifique-francaise
+L'Harmattan	4	7	0	3322	3322	0.002107164358819988	lharmattan
+La Facultad de Economia	1	0	80	80	80	0.0	la-facultad-de-economia
+Laboratoire de Radio Analyse	1	179	0	0	179	1.0	laboratoire-de-radio-analyse
+Lagos University Medical Society	1	0	0	562	562	0.0	lagos-university-medical-society
+Landes Bioscience	1	79	0	86	86	0.9186046511627907	landes-bioscience
+Laser Application in Medical Sciences Research Center	1	0	52	52	52	0.0	laser-application-in-medical-sciences-research-center
+Laser Institute of America	1	1063	0	1113	1113	0.9550763701707098	laser-institute-of-america
+Laser Pages Publishing Ltd.	2	190	0	0	476	0.39915966386554624	laser-pages-publishing-ltd
+Latinoamericana Editores	1	1590	0	0	1590	1.0	latinoamericana-editores
+Latinoamericano de Matematica Educativa	1	0	0	84	84	0.0	latinoamericano-de-matematica-educativa
+Laux Co.	1	119	0	0	119	1.0	laux-co
+Lavoisier	16	4999	0	10607	11456	0.43636522346368717	lavoisier
+Lawtext Publishing Ltd.	2	69	0	80	105	0.6571428571428571	lawtext-publishing-ltd
+Le Jacq Communications, Inc.	7	3370	0	527	3408	0.988849765258216	le-jacq-communications-inc
+Leaf Coppin Publishing Co.	2	1212	0	0	1212	1.0	leaf-coppin-publishing-co
+Learned Information	2	793	0	0	795	0.9974842767295597	learned-information
+LED, Edizioni Universitarie	2	0	0	167	167	0.0	led-edizioni-universitarie
+LED, Edizioni Universitarie di Lettere Economia Diritto	1	0	22	22	22	0.0	led-edizioni-universitarie-di-lettere-economia-diritto
+Leibniz Centre for Agricultural Landscape Research (ZALF)	1	5	21	0	21	0.23809523809523808	leibniz-centre-for-agricultural-landscape-research-zalf
+Leicester Univ. Press	1	238	0	0	238	1.0	leicester-univ-press
+Lemos Editorial & Graficos Ltda.	1	0	33	33	33	0.0	lemos-editorial-graficos-ltda
+Leningradskoe otdelenie	1	0	0	0	1234	0.0	leningradskoe-otdelenie
+Leo Potishman Foundation	1	413	0	0	413	1.0	leo-potishman-foundation
+Les Amis d'Acarologia	1	2	301	301	301	0.006644518272425249	les-amis-dacarologia
+Les Editions de Minuit	1	9	0	437	437	0.020594965675057208	les-editions-de-minuit
+Les Editions de physique	5	410	0	0	14811	0.02768212814799811	les-editions-de-physique
+LESS Catholic University - Sao Paulo	1	0	213	213	213	0.0	less-catholic-university-sao-paulo
+Lexis Publisher	1	0	0	175	175	0.0	lexis-publisher
+Leyden Pub. Co.	1	142	0	0	142	1.0	leyden-pub-co
+Liaquat University of Medical and Health Sciences	1	0	50	50	50	0.0	liaquat-university-of-medical-and-health-sciences
+Libbey	3	177	0	1908	2886	0.061330561330561334	libbey
+Libertas Academica	32	863	2550	2596	2596	0.33243451463790447	libertas-academica
+Librairie Arnette	3	1893	0	0	1893	1.0	librairie-arnette
+Librairie Droz	1	0	156	156	156	0.0	librairie-droz
+Librairie Droz S.A.	1	1	0	0	2853	3.505082369435682e-4	librairie-droz-s-a
+Librairie Generale de Droit et de Jurisprudence	1	0	0	349	349	0.0	librairie-generale-de-droit-et-de-jurisprudence
+Librairie Philosophique J. Vrin	2	21	0	651	651	0.03225806451612903	librairie-philosophique-j-vrin
+Librapharm Ltd.	3	0	0	0	299	0.0	librapharm-ltd
+Library Association	1	11	0	0	11	1.0	library-association
+Library History Group of the Library Association	1	575	0	0	579	0.9930915371329879	library-history-group-of-the-library-association
+Library of the University of Arizona	1	1806	2049	2049	2049	0.8814055636896047	library-of-the-university-of-arizona
+Librello Publishing House	1	0	136	136	136	0.0	librello-publishing-house
+Lietuvos Zemdirbystes Institutas	1	2	0	240	240	0.008333333333333333	lietuvos-zemdirbystes-institutas
+Lifescience Global	4	0	0	401	544	0.0	lifescience-global
+Liga Brasileira de Epilepsia	1	0	0	0	286	0.0	liga-brasileira-de-epilepsia
+Linguistic Society of America	1	8722	0	12166	12166	0.716915995397008	linguistic-society-of-america
+Linkoping University Electronic Press	2	0	459	459	459	0.0	linkoping-university-electronic-press
+Linnean Society of New South Wales	1	0	0	1334	1334	0.0	linnean-society-of-new-south-wales
+Lithuanian Academy of Sciences	2	0	0	229	229	0.0	lithuanian-academy-of-sciences
+Lithuanian Physical Society	1	1	708	708	708	0.0014124293785310734	lithuanian-physical-society
+Liverpool University Press	11	17844	0	17805	23592	0.7563580874872838	liverpool-university-press
+Ljubljana University Press, Faculy of Arts	1	1	263	263	263	0.0038022813688212928	ljubljana-university-press-faculy-of-arts
+LM Sante	1	522	0	0	523	0.9980879541108987	lm-sante
+Lodz University	1	55	0	131	131	0.4198473282442748	lodz-university
+Logos Tip Yayinciligi	3	3	0	1264	1391	0.002156721782890007	logos-tip-yayinciligi
+Logos Yayincilik	1	1	0	0	142	0.007042253521126761	logos-yayincilik
+Logos Yayincilik Ticaret A.S.	1	214	0	440	440	0.4863636363636364	logos-yayincilik-ticaret-a-s
+London Chemical Society	1	20	0	501	501	0.03992015968063872	london-chemical-society
+Longanesi	1	1	722	722	722	0.0013850415512465374	longanesi
+Lucent Technologies	2	1791	0	1128	1805	0.9922437673130194	lucent-technologies
+Lumitext Publishing	1	0	20	20	20	0.0	lumitext-publishing
+M T T Agrifood Research Finland	1	0	239	239	239	0.0	m-t-t-agrifood-research-finland
+M Y U Scientific Publishing Division	1	0	0	317	317	0.0	m-y-u-scientific-publishing-division
+M. Elbeck	1	0	125	125	125	0.0	m-elbeck
+Macedonian Journal of Chemistry and Chemical Engineering	1	0	97	97	97	0.0	macedonian-journal-of-chemistry-and-chemical-engineering
+Macedonian Society of Nephrology, Dialysis, Transplantation and Artificial Organs	1	1	0	12	12	0.08333333333333333	macedonian-society-of-nephrology-dialysis-transplantation-and-artificial-organs
+Magnolia Press	2	6769	0	14601	14601	0.46359838367235123	magnolia-press
+Magyar Biologiai Tarsasag (Hungarian Biological Society)	1	0	0	21	21	0.0	magyar-biologiai-tarsasag-hungarian-biological-society
+Magyar Onkologusok Tarsasaga	1	7	0	170	170	0.041176470588235294	magyar-onkologusok-tarsasaga
+Magyar Termeszettudomanyi Muzeum	1	0	40	40	40	0.0	magyar-termeszettudomanyi-muzeum
+Magyar Tudomanyos Akademia	1	27	0	0	27	1.0	magyar-tudomanyos-akademia
+Magyarhoni Foldtani Tarsulat	1	0	0	5	5	0.0	magyarhoni-foldtani-tarsulat
+Maik Nauka/Interperiodica Publishing	99	208577	0	213586	214536	0.9722237759630086	maik-nauka-interperiodica-publishing
+Maison de la Geology	2	6	0	680	1304	0.004601226993865031	maison-de-la-geology
+Maison des Sciences de l'homme	2	12	0	2430	2430	0.0049382716049382715	maison-des-sciences-de-lhomme
+Maisonneuve et Larose	1	30	0	1181	1181	0.02540220152413209	maisonneuve-et-larose
+Makerere University	1	1	0	771	771	0.0012970168612191958	makerere-university
+Malaysian Institute of Planners	1	0	0	153	153	0.0	malaysian-institute-of-planners
+Malaysian Orthopaedic Association	1	0	0	335	335	0.0	malaysian-orthopaedic-association
+Malaysian Palm Oil Board	1	0	0	56	56	0.0	malaysian-palm-oil-board
+Malaysian Society for Microbiology	1	0	221	221	221	0.0	malaysian-society-for-microbiology
+Malgorzata Pachecka	1	1	0	78	78	0.01282051282051282	malgorzata-pachecka
+Malhotra Publishing House	1	0	0	121	121	0.0	malhotra-publishing-house
+Mallet Conseil	1	5	0	543	543	0.009208103130755065	mallet-conseil
+Mammalogical Society of Japan	1	365	0	524	524	0.6965648854961832	mammalogical-society-of-japan
+Manchester University Press	2	206	0	332	453	0.45474613686534215	manchester-university-press
+Mansell	1	456	0	0	456	1.0	mansell
+Mapping Sciences Institute Australia	1	1459	0	0	1477	0.987813134732566	mapping-sciences-institute-australia
+Marine Biological Laboratory	1	7584	0	8500	8500	0.892235294117647	marine-biological-laboratory
+Marine Technology Society, Inc.	1	1049	0	1167	1167	0.8988860325621251	marine-technology-society-inc
+Mark Allen Publishing Ltd.	11	18446	0	31226	33767	0.5462729884206474	mark-allen-publishing-ltd
+Marmara University	2	69	266	403	403	0.17121588089330025	marmara-university
+Marshfield Clinic	1	1370	1392	1392	1392	0.9841954022988506	marshfield-clinic
+Martin Media	1	1	0	427	427	0.00234192037470726	martin-media
+Maruzen Co., Ltd/Maruzen Kabushikikaisha	6	11794	7016	25772	28954	0.40733577398632315	maruzen-co-ltd-maruzen-kabushikikaisha
+Mary Ann Liebert	119	133117	223	115922	137067	0.9711819766975275	mary-ann-liebert
+Masaryk University	5	246	394	510	510	0.4823529411764706	masaryk-university
+Masarykova Universita	2	0	0	88	88	0.0	masarykova-universita
+MasiMax Resources, Inc.	1	0	0	0	45	0.0	masimax-resources-inc
+Massachusetts Eye and Ear Infirmary	1	35	85	85	85	0.4117647058823529	massachusetts-eye-and-ear-infirmary
+Massachusetts Medical Society	1	180321	0	180467	180467	0.9991909878260291	massachusetts-medical-society
+Materials and Energy Research Center	1	0	54	54	54	0.0	materials-and-energy-research-center
+Materials Research Society	1	78	0	0	218	0.3577981651376147	materials-research-society
+Materials Research Society of Korea	1	4	0	1934	1934	0.002068252326783868	materials-research-society-of-korea
+Mathematica Scandinavica	1	0	2636	2636	2636	0.0	mathematica-scandinavica
+Mathematical Association of America	4	37638	679	38505	38505	0.9774834437086093	mathematical-association-of-america
+Mathematical Association of South Australia	1	494	0	0	494	1.0	mathematical-association-of-south-australia
+Mathematical Biology, Inc	1	1700	0	0	1700	1.0	mathematical-biology-inc
+Mathematical Institute of Charles University	1	0	0	86	86	0.0	mathematical-institute-of-charles-university
+Mathematical Sciences Publishers	5	699	0	1700	1700	0.4111764705882353	mathematical-sciences-publishers
+Mathematical Society of Japan	2	598	0	3337	3337	0.17920287683548097	mathematical-society-of-japan
+Mathematical Society of the Republic of China	1	1	0	473	473	0.0021141649048625794	mathematical-society-of-the-republic-of-china
+Matrice Technology Ltd.	1	151	0	0	151	1.0	matrice-technology-ltd
+Max-Planck Institute for Demographic Research/Max-Planck-institut fur Demografische Forschung	1	11	1076	1076	1076	0.010223048327137546	max-planck-institute-for-demographic-research-max-planck-institut-fur-demografische-forschung
+Max-Planck-Institut fur Sonnensystemforschung	1	58	64	64	64	0.90625	max-planck-institut-fur-sonnensystemforschung
+Maxwell Scientific Publications	2	0	0	0	2705	0.0	maxwell-scientific-publications
+Mazandaran University of Medical Sciences	1	0	0	196	196	0.0	mazandaran-university-of-medical-sciences
+MCB University Press	4	1081	0	0	1338	0.8079222720478326	mcb-university-press
+McFarland & Co.	1	2	0	247	247	0.008097165991902834	mcfarland-co
+McFarland and Company, Inc	1	1	0	194	194	0.005154639175257732	mcfarland-and-company-inc
+McGill University	2	137	0	0	273	0.5018315018315018	mcgill-university
+McMaster University Press	1	0	0	1358	1358	0.0	mcmaster-university-press
+McMaster University, Institute for Energy Studies	1	0	0	0	387	0.0	mcmaster-university-institute-for-energy-studies
+MCSER-Mediterranean Center of Social and Educational research	1	0	0	0	6684	0.0	mcser-mediterranean-center-of-social-and-educational-research
+MechAero Foundation for Technical Research & Education Excellence (MAFTREE)	1	113	0	218	218	0.518348623853211	mechaero-foundation-for-technical-research-education-excellence-maftree
+Mechanical Engineering Publications Ltd.	3	1125	0	0	1346	0.8358098068350669	mechanical-engineering-publications-ltd
+Meckler Pub	1	538	0	0	633	0.8499210110584519	meckler-pub
+Medecine Et Hygiene	1	1	0	548	548	0.0018248175182481751	medecine-et-hygiene
+Media Sphera	1	0	0	137	137	0.0	media-sphera
+Media Sphera Publishing Group	7	0	0	2846	2846	0.0	media-sphera-publishing-group
+Media-Star	1	622	0	0	622	1.0	media-star
+Medical Association of Nippon Medical School/Nippon Ika Daigaku Igakkai	2	0	0	1242	6608	0.0	medical-association-of-nippon-medical-school-nippon-ika-daigaku-igakkai
+Medical Communications	3	0	217	338	338	0.0	medical-communications
+Medical Education Cooperation with Cuba	1	1	61	61	61	0.01639344262295082	medical-education-cooperation-with-cuba
+Medical Journals/Acta D-V	1	2682	3898	3898	3898	0.6880451513596716	medical-journals-acta-d-v
+Medical Library Association	1	366	899	899	899	0.407119021134594	medical-library-association
+Medical Science International Publishing	2	40	2543	2543	2550	0.01568627450980392	medical-science-international-publishing
+Medicina Oral S.L	2	115	2446	2446	2446	0.04701553556827474	medicina-oral-s-l
+Medicine Pub. Co.	1	338	0	0	338	1.0	medicine-pub-co
+Medicine Publishing	2	1518	0	1327	1538	0.9869960988296489	medicine-publishing
+Medicine Publishing Company Ltd.	2	1438	0	652	1441	0.9979181124219292	medicine-publishing-company-ltd
+Medicine Reports Limited	1	11	0	0	242	0.045454545454545456	medicine-reports-limited
+Medicinska Naklada Co.	1	503	879	879	879	0.5722411831626849	medicinska-naklada-co
+MediNews Ltd.	1	0	0	229	229	0.0	medinews-ltd
+MediPoeia	1	35	1177	1177	1177	0.029736618521665252	medipoeia
+Medisa Editora	1	120	2175	2175	2175	0.05517241379310345	medisa-editora
+Mediselect B.V.	1	1283	0	1345	1345	0.9539033457249071	mediselect-b-v
+Mediterranean Society of Otology and Audiology (MSOA)	1	61	0	222	222	0.2747747747747748	mediterranean-society-of-otology-and-audiology-msoa
+Meditsina Publishers	3	0	0	1290	1290	0.0	meditsina-publishers
+Meditsinski Universitet - Sofia	1	144	216	216	216	0.6666666666666666	meditsinski-universitet-sofia
+MedSport Press	3	8	0	468	468	0.017094017094017096	medsport-press
+Medwave Estudios Limitada	1	7	2650	2650	2650	0.0026415094339622643	medwave-estudios-limitada
+Medwell	12	1	286	180	3085	3.2414910858995135e-4	medwell
+Medycyna Weterynaryjna	1	0	0	127	127	0.0	medycyna-weterynaryjna
+Meme Sagligi Dergisi Pleksus BT A.S.	1	79	0	0	95	0.8315789473684211	meme-sagligi-dergisi-pleksus-bt-a-s
+Men's Studies Press	2	109	0	413	413	0.2639225181598063	mens-studies-press
+Mendelova Zemedelska a Lesnicka Univerzita v Brne	1	3	2728	2728	2728	0.0010997067448680353	mendelova-zemedelska-a-lesnicka-univerzita-v-brne
+Mentor Communications AB	1	1	0	1856	1856	5.387931034482759e-4	mentor-communications-ab
+Metallurgical Society of AIME	1	1007	0	0	1007	1.0	metallurgical-society-of-aime
+Metals Society	3	2225	0	0	2289	0.9720401922236784	metals-society
+Meteoritical Society	1	1447	0	0	1447	1.0	meteoritical-society
+Meteorological Society of Japan/Nihon Kisho Gakkai	2	3	1996	1996	1996	0.001503006012024048	meteorological-society-of-japan-nihon-kisho-gakkai
+Methodist DeBakey Heart & Vascular Center	1	584	617	617	617	0.946515397082658	methodist-debakey-heart-vascular-center
+Metropolis	1	2	0	200	200	0.01	metropolis
+Metropolitan Museum	1	4294	0	4294	4294	1.0	metropolitan-museum
+Mezhdunarodnyi Fond Okhrany Zdorov'ya Materi i Rebenka	1	0	0	1	1	0.0	mezhdunarodnyi-fond-okhrany-zdorovya-materi-i-rebenka
+Mi-tec Medical and Scientific Pub	1	152	0	0	152	1.0	mi-tec-medical-and-scientific-pub
+Michigan Academy of Science	1	0	0	0	43	0.0	michigan-academy-of-science
+Michigan Law Review Association	1	17243	0	17243	17243	1.0	michigan-law-review-association
+Michigan State University	2	748	0	420	1146	0.6527050610820244	michigan-state-university
+Michigan State University Press	7	727	0	2183	2183	0.33302794319743473	michigan-state-university-press
+Microbiology Research Foundation	1	2	0	2778	2778	7.199424046076314e-4	microbiology-research-foundation
+Micropaleontology Press	1	1700	0	1703	1703	0.9982384028185555	micropaleontology-press
+Middle East Fertility Society	1	432	444	444	444	0.972972972972973	middle-east-fertility-society
+Middle East Research & Information Project	1	1052	0	1052	1052	1.0	middle-east-research-information-project
+Middle East Studies Association of North America	1	5117	0	0	5132	0.9970771628994544	middle-east-studies-association-of-north-america
+Midwest Modern Language Association	1	418	0	418	418	1.0	midwest-modern-language-association
+Milbank Memorial Fund	1	1415	0	0	1415	1.0	milbank-memorial-fund
+Mineral Research & Exploration General Directorate	1	0	0	73	73	0.0	mineral-research-exploration-general-directorate
+Mineralogical Association of Canada	1	1622	0	1945	1945	0.8339331619537275	mineralogical-association-of-canada
+Mineralogical Society	2	2421	0	12031	12031	0.20123015543180117	mineralogical-society
+Mineralogical Society of America	2	1473	0	1501	1501	0.9813457694870087	mineralogical-society-of-america
+Ministere de l'Economie, Direction de la Prevision	1	17	0	1058	1058	0.01606805293005671	ministere-de-leconomie-direction-de-la-prevision
+Ministere de la Culture	1	7	735	735	735	0.009523809523809525	ministere-de-la-culture
+Ministere du Travail et de la Participation	1	1	0	243	243	0.00411522633744856	ministere-du-travail-et-de-la-participation
+Ministerio de Sanidad y Consumo	1	2	1165	1165	1165	0.0017167381974248926	ministerio-de-sanidad-y-consumo
+Ministry of Agriculture	1	18	0	738	738	0.024390243902439025	ministry-of-agriculture
+MIS Research Center	1	639	0	639	639	1.0	mis-research-center
+Miskolc University Press	1	0	101	101	101	0.0	miskolc-university-press
+Missouri Botanical Garden	2	4607	0	4610	4610	0.999349240780911	missouri-botanical-garden
+MIT Press	30	50180	716	59472	59478	0.8436732909647264	mit-press
+MM Publishing	1	0	370	370	370	0.0	mm-publishing
+MMV-Medizin-Verlag	1	6	0	0	6	1.0	mmv-medizin-verlag
+Modern Education and Computer Science Press	1	19	640	640	640	0.0296875	modern-education-and-computer-science-press
+Modern Humanities Research Association	4	28700	0	29345	29345	0.9780201056398024	modern-humanities-research-association
+Modern Language Association of America (PMLA)	1	6324	0	7414	7414	0.852980847046129	modern-language-association-of-america-pmla
+Mohr Siebeck GmbH and Co. KG	5	1666	0	2004	2004	0.8313373253493014	mohr-siebeck-gmbh-and-co-kg
+Moksha Publishing House	2	2	863	0	1830	0.001092896174863388	moksha-publishing-house
+Moment Publications	1	10	0	489	489	0.02044989775051125	moment-publications
+Monash University	1	0	54	54	54	0.0	monash-university
+Mongabay.com	1	69	452	452	452	0.15265486725663716	mongabay-com
+Montfort Press	1	0	322	322	322	0.0	montfort-press
+Monthly Review Foundation	1	2	0	4891	4891	4.089143324473523e-4	monthly-review-foundation
+Morgan & Claypool Publishers	16	295	0	242	298	0.9899328859060402	morgan-claypool-publishers
+Morgan and Claypool Publishers	1	11	0	0	11	1.0	morgan-and-claypool-publishers
+Moskovskii Gosudarstvennyi Institut Stali i Splavov	1	0	0	671	671	0.0	moskovskii-gosudarstvennyi-institut-stali-i-splavov
+Mount Sinai Hospital	1	377	0	0	377	1.0	mount-sinai-hospital
+Mrs Dipika Charan for MedScience Publishers	1	140	483	483	483	0.2898550724637681	mrs-dipika-charan-for-medscience-publishers
+Multi-Science Publishing Co Ltd.	4	477	0	100	968	0.4927685950413223	multi-science-publishing-co-ltd
+Multidisciplinary Digital Publishing Institute (MDPI)	59	24508	80672	82918	82918	0.29556911647651896	multidisciplinary-digital-publishing-institute-mdpi
+Multimed Inc.	3	1301	175	2457	2457	0.5295075295075296	multimed-inc
+Multiphysics	1	116	0	288	288	0.4027777777777778	multiphysics
+Multivers Publishers ApS	1	0	0	457	457	0.0	multivers-publishers-aps
+Museo Argentino de Ciencias Naturales Bernardino Rivadavia e Instituto Nacional de Investigacion de las Ciencias Naturales	2	0	247	247	494	0.0	museo-argentino-de-ciencias-naturales-bernardino-rivadavia-e-instituto-nacional-de-investigacion-de-las-ciencias-naturales
+Museo Chileno de Arte Precolombino	1	0	109	109	109	0.0	museo-chileno-de-arte-precolombino
+Museu Paraense Emilio Goeldi	1	1	37	37	37	0.02702702702702703	museu-paraense-emilio-goeldi
+Museum and Institute of Zoology PAS	1	588	0	591	591	0.9949238578680203	museum-and-institute-of-zoology-pas
+Museum d'Histoire Naturelle de Geneve	1	0	0	3178	3178	0.0	museum-dhistoire-naturelle-de-geneve
+Museum National d'Histoire Naturelle	6	786	972	1106	1108	0.7093862815884476	museum-national-dhistoire-naturelle
+Museum Rietberg	1	2167	0	2167	2167	1.0	museum-rietberg
+Museum Victoria	1	0	0	51	51	0.0	museum-victoria
+Music Library Association	1	11760	0	14534	14534	0.8091371955414889	music-library-association
+Muzikoloski institut, Znanstvenoraziskovalni center SAZU	1	0	0	156	156	0.0	muzikoloski-institut-znanstvenoraziskovalni-center-sazu
+Mycotaxon Ltd.	1	1354	0	1508	1508	0.8978779840848806	mycotaxon-ltd
+MYJoVE Corporation	1	963	0	5974	5974	0.1611985269501172	myjove-corporation
+Mymensingh Medical College	1	0	0	74	74	0.0	mymensingh-medical-college
+N T C Publications Ltd.	1	1	0	539	539	0.0018552875695732839	n-t-c-publications-ltd
+NACE International	1	7362	0	7395	7395	0.9955375253549695	nace-international
+Naklada Slap	1	0	0	9	9	0.0	naklada-slap
+Nakladatelske Stredisko CLSJE Purkyne	3	0	0	226	341	0.0	nakladatelske-stredisko-clsje-purkyne
+Nakladem Uniwersytetu Marii Curie-Sklodowskiej i Akademii Medycznej	1	0	0	0	196	0.0	nakladem-uniwersytetu-marii-curie-sklodowskiej-i-akademii-medycznej
+Nanjing Medical University	2	442	0	473	722	0.6121883656509696	nanjing-medical-university
+Nankodo Co., Ltd.	1	0	0	0	4857	0.0	nankodo-co-ltd
+Nanzan Institute for Religion and Culture	2	0	1353	1353	1353	0.0	nanzan-institute-for-religion-and-culture
+Nanzan University Institute of Anthropology	1	1389	0	0	1389	1.0	nanzan-university-institute-of-anthropology
+Narodni Muzeum	2	16	0	21	62	0.25806451612903225	narodni-muzeum
+National Academy of Sciences	1	123984	0	132761	132761	0.9338887173190922	national-academy-of-sciences
+National Academy of Sciences of Ukraine	3	0	387	680	680	0.0	national-academy-of-sciences-of-ukraine
+National Assn. of Social Workers	1	943	0	1258	1258	0.7496025437201908	national-assn-of-social-workers
+National Association for Healthcare Quality	1	1	0	0	1	1.0	national-association-for-healthcare-quality
+National Association of Biology Teachers Inc.	1	17784	0	18056	18056	0.9849357554275587	national-association-of-biology-teachers-inc
+National Association of Forensic Doctors	1	278	0	282	282	0.9858156028368794	national-association-of-forensic-doctors
+National Association of Geoscience Teachers, Inc.	2	6	0	1541	4272	0.0014044943820224719	national-association-of-geoscience-teachers-inc
+National Association of Resident Doctors of Nigeria	1	0	0	461	461	0.0	national-association-of-resident-doctors-of-nigeria
+National Association of School Psychologists	1	0	0	81	81	0.0	national-association-of-school-psychologists
+National Association of Social Workers Press	1	1499	0	2197	2197	0.6822940373236231	national-association-of-social-workers-press
+National Athletic Trainers Association, Inc.	1	683	1059	1059	1059	0.6449480642115203	national-athletic-trainers-association-inc
+National Authority Remote Sensing and Space Sciences	1	203	208	208	208	0.9759615384615384	national-authority-remote-sensing-and-space-sciences
+National Autonomous University of Mexico, Faculty of Chemistry	1	257	0	265	265	0.969811320754717	national-autonomous-university-of-mexico-faculty-of-chemistry
+National Bureau of Standards	1	0	0	0	533	0.0	national-bureau-of-standards
+National Cancer Institute	1	217	222	222	222	0.9774774774774775	national-cancer-institute
+National Catholic Bioethics Center	1	0	0	0	1373	0.0	national-catholic-bioethics-center
+National Center for American Indian Mental Health Research	1	0	0	360	360	0.0	national-center-for-american-indian-mental-health-research
+National Center for Scientific Research	1	26	0	891	891	0.029180695847362513	national-center-for-scientific-research
+National Center for Transit Research	1	0	0	408	408	0.0	national-center-for-transit-research
+National Centre for Marine Research	1	1	578	578	578	0.0017301038062283738	national-centre-for-marine-research
+National Cheng Kung University	1	75	0	80	80	0.9375	national-cheng-kung-university
+National Conference of Catholic Charities	1	777	0	0	907	0.856670341786108	national-conference-of-catholic-charities
+National Coordinating Centre for Health Technology Assessment	1	31	0	968	968	0.03202479338842975	national-coordinating-centre-for-health-technology-assessment
+National Council of Teachers of English	2	11869	0	11869	11869	1.0	national-council-of-teachers-of-english
+National Council of Teachers of Mathematics	1	1271	0	1274	1274	0.9976452119309263	national-council-of-teachers-of-mathematics
+National Council on Family Relations	1	1998	0	0	1998	1.0	national-council-on-family-relations
+National Defence Medical Center	1	1	0	172	172	0.005813953488372093	national-defence-medical-center
+National documentation centre	1	0	0	252	252	0.0	national-documentation-centre
+National Engineering Research Center for Magnesium Alloys of China, Chongqing University	1	202	203	203	203	0.9950738916256158	national-engineering-research-center-for-magnesium-alloys-of-china-chongqing-university
+National Head Start Association (NHSA)	1	358	0	0	386	0.927461139896373	national-head-start-association-nhsa
+National Hellenic Research Foundation, Institute of Historical Research	2	0	171	609	609	0.0	national-hellenic-research-foundation-institute-of-historical-research
+National Herbarium Nederland/Leiden Branch	2	605	203	675	675	0.8962962962962963	national-herbarium-nederland-leiden-branch
+National Herbarium of New South Wales	1	1	0	643	643	0.0015552099533437014	national-herbarium-of-new-south-wales
+National Institute for Pharmaceutical Research and Development	1	0	0	0	45	0.0	national-institute-for-pharmaceutical-research-and-development
+National Institute of Advanced Industrial Science and Technology	1	0	0	326	326	0.0	national-institute-of-advanced-industrial-science-and-technology
+National Institute of Industrial Health	1	105	2348	2348	2348	0.04471890971039182	national-institute-of-industrial-health
+National Institute of Infectious Diseases	2	1	0	658	2246	4.452359750667854e-4	national-institute-of-infectious-diseases
+National Institute of Informatics	1	0	0	0	94	0.0	national-institute-of-informatics
+National Institute of Oceanography and Fisheries	1	219	223	223	223	0.9820627802690582	national-institute-of-oceanography-and-fisheries
+National Institute Of Science And Technology	1	0	0	24	24	0.0	national-institute-of-science-and-technology
+National Institute of Standards and Technology	1	3	1212	1212	1212	0.0024752475247524753	national-institute-of-standards-and-technology
+National Library of Ukraine Vernadsky	1	0	0	88	88	0.0	national-library-of-ukraine-vernadsky
+National Medical Association	1	1475	1514	1514	1514	0.9742404227212682	national-medical-association
+National Medical Research Radiological Centre of the Ministry of Health of the Russian Federation	1	0	0	27	27	0.0	national-medical-research-radiological-centre-of-the-ministry-of-health-of-the-russian-federation
+National Postgraduate Medical College of Nigeria	1	0	0	0	61	0.0	national-postgraduate-medical-college-of-nigeria
+National Prescribing Service	1	0	2575	2575	2575	0.0	national-prescribing-service
+National Public Health Institution of Turkey	1	98	198	198	198	0.494949494949495	national-public-health-institution-of-turkey
+National Research Center Kurchatov Institute	1	0	0	187	187	0.0	national-research-center-kurchatov-institute
+National Research Council	1	574	0	584	584	0.9828767123287672	national-research-council
+National Research Council Canada	4	5079	0	1702	5445	0.9327823691460055	national-research-council-canada
+National Research Ogarev Mordovia State University	1	0	213	213	213	0.0	national-research-ogarev-mordovia-state-university
+National Research University	2	0	0	317	317	0.0	national-research-university
+National Research University Higher School of Economics	7	0	901	1319	1319	0.0	national-research-university-higher-school-of-economics
+National Science Foundation of Sri Lanka	2	0	0	840	840	0.0	national-science-foundation-of-sri-lanka
+National Shellfisheries Association, Inc.	1	1368	0	1374	1374	0.9956331877729258	national-shellfisheries-association-inc
+National Speleological Society, Inc.	1	2	0	161	161	0.012422360248447204	national-speleological-society-inc
+National Strength and Conditioning Association	1	5536	0	7487	7487	0.7394149859756912	national-strength-and-conditioning-association
+National Tax Association	1	0	0	779	779	0.0	national-tax-association
+National University of Singapore, Department of Biological Sciences, Centre for Biomedical Ethics	1	7	0	183	183	0.03825136612021858	national-university-of-singapore-department-of-biological-sciences-centre-for-biomedical-ethics
+National'na Akademiya Nauk Ukrainy	1	0	0	0	71	0.0	nationalna-akademiya-nauk-ukrainy
+Nationale Plantentuin van België	1	261	0	287	287	0.9094076655052264	nationale-plantentuin-van-belgie
+Natsionl'nyi Tekhhichnyi Universiytet Ukrainy	1	0	0	0	92	0.0	natsionlnyi-tekhhichnyi-universiytet-ukrainy
+Natural Areas Association	1	638	0	671	671	0.9508196721311475	natural-areas-association
+Natural Remedies Pvt Ltd.	1	0	0	24	24	0.0	natural-remedies-pvt-ltd
+Natural Resources Institute	1	904	0	0	904	1.0	natural-resources-institute
+Natural Sciences Publishing Corporation	1	24	0	1304	1304	0.018404907975460124	natural-sciences-publishing-corporation
+Nauchno-tekhnicheskii Tsentr	1	0	0	45	45	0.0	nauchno-tekhnicheskii-tsentr
+Nauchnoe Obshchestvo Rentgenologov i Radiologov	1	0	0	50	50	0.0	nauchnoe-obshchestvo-rentgenologov-i-radiologov
+Nauka Publishers	2	0	0	766	766	0.0	nauka-publishers
+Naukova Dumka	3	336	2571	3168	3168	0.10606060606060606	naukova-dumka
+Nederlandse Entomoligische Vereniging	1	0	0	0	17	0.0	nederlandse-entomoligische-vereniging
+Nenryo Kyokai	1	0	0	0	9638	0.0	nenryo-kyokai
+Neoplasia Press	1	589	605	605	605	0.9735537190082645	neoplasia-press
+Nepal Ophthalmic Society	1	0	357	357	357	0.0	nepal-ophthalmic-society
+Nepal Paediatric Society	1	151	462	462	462	0.3268398268398268	nepal-paediatric-society
+Netherlands Institute voor Geontologie	1	653	0	668	668	0.9775449101796407	netherlands-institute-voor-geontologie
+Netherlandse Ornithologische Unie/Netherlands Ornithological Union	1	395	0	401	401	0.9850374064837906	netherlandse-ornithologische-unie-netherlands-ornithological-union
+Neuroline	1	0	0	5	5	0.0	neuroline
+NeuroQuantology	1	64	0	732	732	0.08743169398907104	neuroquantology
+Neuroscience Publications	1	2	658	0	658	0.00303951367781155	neuroscience-publications
+Neva Press, Inc.	2	1000	0	0	1002	0.998003992015968	neva-press-inc
+New England Botanical Club, Inc.	1	423	0	441	441	0.9591836734693877	new-england-botanical-club-inc
+New Jersey Institute of Technology	1	755	0	0	808	0.9344059405940595	new-jersey-institute-of-technology
+New South Wales Department Health	1	36	1815	0	1815	0.019834710743801654	new-south-wales-department-health
+New York Academy of Sciences	1	3834	0	0	3834	1.0	new-york-academy-of-sciences
+New York Entomological Society	2	303	0	137	305	0.9934426229508196	new-york-entomological-society
+New York State Historical Association	1	16	0	0	31	0.5161290322580645	new-york-state-historical-association
+New Zealand Council for Educational Research Press	1	0	0	17	17	0.0	new-zealand-council-for-educational-research-press
+New Zealand Geographical Society Inc.	1	836	0	0	836	1.0	new-zealand-geographical-society-inc
+Newman Pub	1	603	0	0	768	0.78515625	newman-pub
+Nexus Academic Publishers	1	13	0	371	371	0.03504043126684636	nexus-academic-publishers
+Nexus Ediciones	1	38	0	38	38	1.0	nexus-ediciones
+Nicolaus Copernicus University	3	46	495	779	779	0.059050064184852376	nicolaus-copernicus-university
+Nigerian Medical Association	2	636	0	0	894	0.7114093959731543	nigerian-medical-association
+Nigerian Mining and Geosciences Society	1	0	0	0	132	0.0	nigerian-mining-and-geosciences-society
+Nigerian Society of Parasitology	1	0	0	0	244	0.0	nigerian-society-of-parasitology
+Nihon Akuseru Shupuringa Shuppan K.K./Axel Springer Nature	1	4	0	771	771	0.005188067444876783	nihon-akuseru-shupuringa-shuppan-k-k-axel-springer-nature
+Nihon Chaoonpa Igakkai	1	0	0	745	745	0.0	nihon-chaoonpa-igakkai
+Nihon Dokusei Byori Gakkai	1	116	0	1051	1051	0.11037107516650808	nihon-dokusei-byori-gakkai
+Nihon Heiko Shinkeika Gakkai/Japan Society for Equilibrium Research	1	0	0	2121	2121	0.0	nihon-heiko-shinkeika-gakkai-japan-society-for-equilibrium-research
+Nihon Hoshasen Gijutsu Gakkai/Japanese Society of Radiological Technology	1	831	0	1934	1934	0.4296794208893485	nihon-hoshasen-gijutsu-gakkai-japanese-society-of-radiological-technology
+Nihon Hotetsu shika Gakkai/Japan Prosthodontic Society	1	0	0	0	3942	0.0	nihon-hotetsu-shika-gakkai-japan-prosthodontic-society
+Nihon Kango Kagaku Gakkai/Japan Academy of Nursing Science	1	0	0	0	2276	0.0	nihon-kango-kagaku-gakkai-japan-academy-of-nursing-science
+Nihon Kansensho Gakkai	1	4663	0	4665	4665	0.9995712754555198	nihon-kansensho-gakkai
+Nihon Koku Uchu Gakkai	1	0	0	677	677	0.0	nihon-koku-uchu-gakkai
+Nihon Koubutsu Gakkai	1	0	0	523	523	0.0	nihon-koubutsu-gakkai
+Nihon Kyobu Geka Gakkai	1	1432	0	0	1433	0.9993021632937893	nihon-kyobu-geka-gakkai
+Nihon No Shinkei Geka Konguresu/Japanese Congress of Neurological Surgeons	1	0	0	462	462	0.0	nihon-no-shinkei-geka-konguresu-japanese-congress-of-neurological-surgeons
+Nihon Onkyo Gakkai/Acoustical Society of Japan	1	0	0	0	862	0.0	nihon-onkyo-gakkai-acoustical-society-of-japan
+Nihon Rinpa Monaikei Gakkai	1	0	317	317	317	0.0	nihon-rinpa-monaikei-gakkai
+Nihon Rinsho Yakuri Gakkai/Japanese Society of Clinical Pharmacology and Therapeutics	1	0	0	7509	7509	0.0	nihon-rinsho-yakuri-gakkai-japanese-society-of-clinical-pharmacology-and-therapeutics
+Nihon Ronen Igakkai/Japan Geriatrics Society	1	0	0	4586	4586	0.0	nihon-ronen-igakkai-japan-geriatrics-society
+Nihon Sangyo Eisei Gakkai	1	6	0	363	363	0.01652892561983471	nihon-sangyo-eisei-gakkai
+Nihon Shika Riko Gakkai/Japanese Society for Dental Materials and Devices	1	397	0	2148	2148	0.18482309124767227	nihon-shika-riko-gakkai-japanese-society-for-dental-materials-and-devices
+Nihon Shokaki Geka Gakkai/Japanese Society of Gastroenterological Surgery	1	0	0	9906	9906	0.0	nihon-shokaki-geka-gakkai-japanese-society-of-gastroenterological-surgery
+Nihon Soshikigaku Kirokukai	1	1683	0	0	1741	0.9666858127512924	nihon-soshikigaku-kirokukai
+Nihon Tenkan Gakkai/Japan Epilepsy Society	2	0	0	618	618	0.0	nihon-tenkan-gakkai-japan-epilepsy-society
+Nihon Tokeibu Gan Gakkai	1	0	0	811	811	0.0	nihon-tokeibu-gan-gakkai
+Nihon Uchu Seibutsu Kagakka/Japanese Society for Biological Sciences in Space	1	0	0	0	435	0.0	nihon-uchu-seibutsu-kagakka-japanese-society-for-biological-sciences-in-space
+Nihon Uirusu Gakkal/Japanese Society for Virology	1	0	0	1547	1547	0.0	nihon-uirusu-gakkal-japanese-society-for-virology
+Nihon University	2	1795	1030	1030	1838	0.9766050054406964	nihon-university
+Nihon/Haigan Gakkai/Japan Lung Cancer Society	1	0	0	3452	3452	0.0	nihon-haigan-gakkai-japan-lung-cancer-society
+Nippon Bitamin Gakkai/Vitamin Society of Japan	1	0	0	0	801	0.0	nippon-bitamin-gakkai-vitamin-society-of-japan
+Nippon Chiri-Gakkai	2	0	0	491	4506	0.0	nippon-chiri-gakkai
+Nippon Gakushiin/Japan Academy	2	2715	2436	5270	5270	0.5151802656546489	nippon-gakushiin-japan-academy
+Nippon Gyogaku Shinkokai	1	35	0	0	35	1.0	nippon-gyogaku-shinkokai
+Nippon Iden Gakkai	1	3039	0	0	3039	1.0	nippon-iden-gakkai
+Nippon Kinzoku Gakkai	1	3079	0	3175	3175	0.9697637795275591	nippon-kinzoku-gakkai
+Nippon Shokubutsu Gakkai	1	793	0	0	6251	0.12685970244760839	nippon-shokubutsu-gakkai
+Nippon Tekko Kyokai/Iron and Steel Institute of Japan	3	555	0	8166	9290	0.05974165769644779	nippon-tekko-kyokai-iron-and-steel-institute-of-japan
+Nippon Yakuri Gakkai	1	5739	0	5847	5847	0.9815289892252437	nippon-yakuri-gakkai
+Nippon-Shinzobyo-Gakkai/Japanese College of Cardiology	1	1501	0	1521	1521	0.9868507560815253	nippon-shinzobyo-gakkai-japanese-college-of-cardiology
+Niu Terra	1	0	0	0	89	0.0	niu-terra
+Nizhny Novgorod State Medical Academy of the Ministry of Health of the Russian Federation	1	0	202	202	202	0.0	nizhny-novgorod-state-medical-academy-of-the-ministry-of-health-of-the-russian-federation
+Nomos Verlagsgesellschaft	2	0	0	715	715	0.0	nomos-verlagsgesellschaft
+Noncommercial Partnership Editorial Board Polis	1	0	0	799	799	0.0	noncommercial-partnership-editorial-board-polis
+Nonferrous Metals Society of China/Zhongguo Youse Jinshu Xuehui	1	5177	0	5194	5194	0.996726992683866	nonferrous-metals-society-of-china-zhongguo-youse-jinshu-xuehui
+Nordic Council for Wildlife Research	1	580	596	596	596	0.9731543624161074	nordic-council-for-wildlife-research
+Norois	1	1	0	0	2118	4.7214353163361664e-4	norois
+Norsk Entomologisk Forening	1	1	63	63	63	0.015873015873015872	norsk-entomologisk-forening
+Norsk Geologisk Forening/Norwegian Geological Society	1	35	0	43	43	0.813953488372093	norsk-geologisk-forening-norwegian-geological-society
+Norsk Utenrikspolitisk Institutt/Norwegian Institute of International Affairs	1	0	60	60	60	0.0	norsk-utenrikspolitisk-institutt-norwegian-institute-of-international-affairs
+Norske Sykepleierforbund	1	0	0	0	598	0.0	norske-sykepleierforbund
+North American Association for the Study of Obesity	1	1958	0	0	1966	0.9959308240081384	north-american-association-for-the-study-of-obesity
+North American Benthological Society	1	1744	0	0	1900	0.9178947368421052	north-american-benthological-society
+North American Cartographic Information Society	1	11	0	1244	1244	0.008842443729903537	north-american-cartographic-information-society
+North American Society for Sport History	1	75	0	217	217	0.3456221198156682	north-american-society-for-sport-history
+North Carolina Medical Society	1	61	0	336	336	0.18154761904761904	north-carolina-medical-society
+North Carolina University	1	6	2722	2722	2722	0.002204261572373255	north-carolina-university
+North Shore - Long Jewish Research Institute	1	28	956	956	956	0.029288702928870293	north-shore-long-jewish-research-institute
+North-West University	1	139	0	609	609	0.22824302134646962	north-west-university
+Northeast Forestry University	1	1757	0	1792	1792	0.98046875	northeast-forestry-university
+Northwest Atlantic Fisheries Organization	2	5	0	467	467	0.010706638115631691	northwest-atlantic-fisheries-organization
+Northwestern University	1	2173	0	0	2173	1.0	northwestern-university
+Northwestern University Press	1	143	0	617	617	0.23176661264181522	northwestern-university-press
+Norwegian Epidemiological Society	1	0	678	678	678	0.0	norwegian-epidemiological-society
+Norwegian Medical Assocation	1	0	0	9994	9994	0.0	norwegian-medical-assocation
+Nouva Casa Edtrice Licino Cappelli GEM	1	66	0	0	67	0.9850746268656716	nouva-casa-edtrice-licino-cappelli-gem
+Nouveau Monde Editions	1	15	0	632	632	0.023734177215189875	nouveau-monde-editions
+Novello & Co.	1	31791	0	0	31791	1.0	novello-co
+Novosibirsk State Pedagogical University	1	1	0	285	285	0.0035087719298245615	novosibirsk-state-pedagogical-university
+Now Publishers Inc	19	667	0	807	819	0.8144078144078144	now-publishers-inc
+NRC Research Press	16	133464	0	130553	146616	0.9102962841708954	nrc-research-press
+NSCA National Strength and Conditioning Association	2	1	0	0	1279	7.818608287724785e-4	nsca-national-strength-and-conditioning-association
+Nuclear Receptor Signaling Atlas	1	6	99	99	99	0.06060606060606061	nuclear-receptor-signaling-atlas
+Nucleo de Comunicacao, Fundacao UNI	1	0	919	919	919	0.0	nucleo-de-comunicacao-fundacao-uni
+Nucleo de Estudos e Pesquisas Ambientais	1	2	281	281	281	0.0071174377224199285	nucleo-de-estudos-e-pesquisas-ambientais
+Numdam (Numerisation de Documents Anciens Mathematiques)	1	2	0	382	382	0.005235602094240838	numdam-numerisation-de-documents-anciens-mathematiques
+Nursecom Publication	1	828	0	0	864	0.9583333333333334	nursecom-publication
+Obsidiana Editores	1	345	0	364	364	0.9478021978021978	obsidiana-editores
+Obstetrical & Gynaecological Society of Bangladesh	1	0	0	203	203	0.0	obstetrical-gynaecological-society-of-bangladesh
+Obuda University	1	0	391	391	391	0.0	obuda-university
+Oceanography Society	1	7	0	1893	1893	0.0036978341257263604	oceanography-society
+Oceanside Publications, Inc.	3	4698	0	4800	4889	0.9609327060748619	oceanside-publications-inc
+OECD	2	0	0	101	173	0.0	oecd
+Oekom - Gesellschaft fuer Oekologische Kommunikation mbH	1	162	0	1605	1605	0.10093457943925234	oekom-gesellschaft-fuer-oekologische-kommunikation-mbh
+Oeska geologicka spoleonost	1	0	0	0	1	0.0	oeska-geologicka-spoleonost
+Oesterreichische Geographische Gesellschaft	1	0	0	140	140	0.0	oesterreichische-geographische-gesellschaft
+Office International des Epizooties (OIE)	1	0	0	2422	2422	0.0	office-international-des-epizooties-oie
+Office of Population Research	1	323	0	0	323	1.0	office-of-population-research
+Oficyna Wydawnicza Politechniki Warszawskiej	1	75	0	118	118	0.635593220338983	oficyna-wydawnicza-politechniki-warszawskiej
+Oficyna Wydawnicza Politechniki Wroclawskiej	1	88	0	131	131	0.6717557251908397	oficyna-wydawnicza-politechniki-wroclawskiej
+Oficyna Wydawnicza SIMP Press Ltd.	1	0	0	0	66	0.0	oficyna-wydawnicza-simp-press-ltd
+Ohio Academy of Science	1	0	0	0	11	0.0	ohio-academy-of-science
+Ohio State University Press	2	7697	0	8342	8342	0.9226804123711341	ohio-state-university-press
+Oil & Colour Chemists' Association	2	459	0	0	459	1.0	oil-colour-chemists-association
+OilGasScientificResearchProject Institute of State Oil Company of Azerbaijan Republic (SOCAR)	1	0	0	310	310	0.0	oilgasscientificresearchproject-institute-of-state-oil-company-of-azerbaijan-republic-socar
+Okajimas Folia Anatomica Yaponika Henshubu	1	0	0	2277	2277	0.0	okajimas-folia-anatomica-yaponika-henshubu
+Old City Publishing	5	1228	0	1864	1894	0.648363252375924	old-city-publishing
+Oleffe	1	0	0	1834	1834	0.0	oleffe
+Oliver and Boyd Ltd.	1	6530	0	0	6530	1.0	oliver-and-boyd-ltd
+Oman Medical Specialty Board	1	284	814	814	814	0.3488943488943489	oman-medical-specialty-board
+Omics Publishing Group	15	196	0	0	7029	0.02788447858870394	omics-publishing-group
+OmniaScience	2	5	565	565	565	0.008849557522123894	omniascience
+Omohundro Institute of Early American History and Culture	1	10119	0	10242	10242	0.9879906268306972	omohundro-institute-of-early-american-history-and-culture
+Oncology Nursing Society	2	2292	0	3648	3648	0.6282894736842105	oncology-nursing-society
+Ondokuz Mayis University	1	41	0	400	400	0.1025	ondokuz-mayis-university
+Onkoloski Institut Ljubljana/Institute of Oncology Ljubljana	1	235	465	465	465	0.5053763440860215	onkoloski-institut-ljubljana-institute-of-oncology-ljubljana
+Open Access House of Science and Technology (OAHOST)	1	76	0	229	229	0.3318777292576419	open-access-house-of-science-and-technology-oahost
+Open Access Science Online	1	399	481	481	481	0.8295218295218295	open-access-science-online
+Open Learning on Enteric Pathogens	1	435	0	1563	1563	0.2783109404990403	open-learning-on-enteric-pathogens
+OpenJournals Publishing AOSIS (Pty) Ltd	18	1374	15536	15689	15718	0.08741570174322433	openjournals-publishing-aosis-pty-ltd
+Operations Research Society of America	1	241	0	0	279	0.8637992831541219	operations-research-society-of-america
+Operations Research Society of Japan	1	0	0	89	89	0.0	operations-research-society-of-japan
+OPS/OMS, Unidad de Bioetica	1	0	506	506	506	0.0	ops-oms-unidad-de-bioetica
+Optical Society of America	11	118745	36294	109615	126135	0.9414119792286043	optical-society-of-america
+Optical Society of Korea	1	584	0	1097	1097	0.5323609845031905	optical-society-of-korea
+Optometrists Association Australia	2	2904	0	0	2904	1.0	optometrists-association-australia
+Opulus Press AB	1	0	0	0	35	0.0	opulus-press-ab
+Orac	1	116	0	0	116	1.0	orac
+Ordem dos Medicos	1	0	513	513	513	0.0	ordem-dos-medicos
+Order of Physicians in Lebanon	1	0	0	166	166	0.0	order-of-physicians-in-lebanon
+Ore & Metals Publishing House	6	0	0	1059	1059	0.0	ore-metals-publishing-house
+Oregon Historical Society	1	537	0	671	671	0.8002980625931445	oregon-historical-society
+Organisation for Economic Co-operation and Development	2	2	0	77	147	0.013605442176870748	organisation-for-economic-co-operation-and-development
+Organization of American Historians	1	1592	0	0	1592	1.0	organization-of-american-historians
+Organization of the Petroleum Exporting Countries	1	757	0	0	759	0.997364953886693	organization-of-the-petroleum-exporting-countries
+Oriental Scientific Pub. Co.	3	8	2518	977	2623	0.0030499428135722455	oriental-scientific-pub-co
+Ornithological Society of Japan	1	256	0	342	342	0.7485380116959064	ornithological-society-of-japan
+Orta Dogu Teknik Universitesi	1	2	0	204	204	0.00980392156862745	orta-dogu-teknik-universitesi
+Orthopterist's Society	1	615	0	615	615	1.0	orthopterists-society
+OSA Publishing	2	551	0	849	849	0.6489988221436984	osa-publishing
+Oslo and Akershus University College of Applied Sciences	1	0	98	98	98	0.0	oslo-and-akershus-university-college-of-applied-sciences
+Oslo Bioimpedance Group, Department of Physics, University of Oslo	1	0	73	73	73	0.0	oslo-bioimpedance-group-department-of-physics-university-of-oslo
+Oslo Scandinavian University Press	1	1046	0	0	1086	0.9631675874769797	oslo-scandinavian-university-press
+Ossolineum Publishing House	1	589	0	597	597	0.9865996649916248	ossolineum-publishing-house
+Osterreichische Geologische Gesellschaft	1	0	33	33	33	0.0	osterreichische-geologische-gesellschaft
+Ottawa Field-Naturalists' Club	1	0	0	1762	1762	0.0	ottawa-field-naturalists-club
+Oud-Studentenbonden van de Belgische Brouwerijscholen	1	125	0	0	125	1.0	oud-studentenbonden-van-de-belgische-brouwerijscholen
+Overseas Ministries Study Center	1	314	0	314	314	1.0	overseas-ministries-study-center
+Oxford Brookes University	1	136	0	354	354	0.384180790960452	oxford-brookes-university
+Oxford University Press	316	1567250	71136	1748720	1774511	0.8832010621517703	oxford-university-press
+P N G Publications	1	1244	0	1303	1303	0.9547198772064467	p-n-g-publications
+Pacific Coast Entomological Society	1	380	0	410	410	0.926829268292683	pacific-coast-entomological-society
+Pacific Northwest Fungi Project	1	0	90	90	90	0.0	pacific-northwest-fungi-project
+Pacini Editore SpA	1	36	0	36	36	1.0	pacini-editore-spa
+PagePress	27	1820	7531	8027	8064	0.22569444444444445	pagepress
+Pakistan Association of Advancement in Agricultural Sciences	1	0	0	124	124	0.0	pakistan-association-of-advancement-in-agricultural-sciences
+Palacky University	1	0	152	152	152	0.0	palacky-university
+Palladin Institute of Biochemistry of the NASU	2	0	0	716	716	0.0	palladin-institute-of-biochemistry-of-the-nasu
+Pan African Association of Neurological Sciences	1	0	141	141	141	0.0	pan-african-association-of-neurological-sciences
+Pan African Medical Journal	1	31	3872	3872	3872	0.008006198347107437	pan-african-medical-journal
+Pan African Urological Surgeons Association (Pausa)	1	477	489	489	489	0.9754601226993865	pan-african-urological-surgeons-association-pausa
+Pan American Health Organization/Organizacion Panamericana de la Salud	1	11	2784	2784	2784	0.003951149425287357	pan-american-health-organization-organizacion-panamericana-de-la-salud
+Panstwowy Instytut Weterenaryjny/National Veterinary Research Institute	1	117	232	0	232	0.5043103448275862	panstwowy-instytut-weterenaryjny-national-veterinary-research-institute
+Panstwowy Zaklad Wydawnictw Lekarskich	3	2	656	904	999	0.002002002002002002	panstwowy-zaklad-wydawnictw-lekarskich
+Pappin Communications	1	1	0	467	467	0.0021413276231263384	pappin-communications
+Paradigm Press	2	1685	0	0	1685	1.0	paradigm-press
+Parental Drug Association	1	372	0	382	382	0.9738219895287958	parental-drug-association
+Parthenon Publishing Group	4	413	0	0	1352	0.30547337278106507	parthenon-publishing-group
+Pasteur Institute of Iran	1	0	0	24	24	0.0	pasteur-institute-of-iran
+Pavilion	2	806	0	0	832	0.96875	pavilion
+PC Technology Center	1	7	1785	1785	1785	0.00392156862745098	pc-technology-center
+Peabody Museum of Natural History	1	135	0	138	138	0.9782608695652174	peabody-museum-of-natural-history
+PeerJ	1	25	3103	3103	3103	0.008056719303899453	peerj
+Peeters Publishers	29	95	0	13508	14506	0.006549014201020268	peeters-publishers
+Peking University and Nanjing University	1	347	0	0	347	1.0	peking-university-and-nanjing-university
+Penerbit Universiti Kebangsaan Malaysia	1	0	119	119	119	0.0	penerbit-universiti-kebangsaan-malaysia
+Penerbit Universiti Sains Malaysia	4	0	71	80	80	0.0	penerbit-universiti-sains-malaysia
+Penerbit Universiti Teknologi Malaysia	1	0	0	4536	4536	0.0	penerbit-universiti-teknologi-malaysia
+Penn State University Press	14	2968	0	5076	5076	0.5847123719464145	penn-state-university-press
+Pensoft Publishers	14	6245	8560	11970	11970	0.5217209690893901	pensoft-publishers
+Perm National Research Polytechnic University	2	0	0	197	197	0.0	perm-national-research-polytechnic-university
+Perspectives of New Music	1	1397	0	1423	1423	0.9817287420941673	perspectives-of-new-music
+Perston Publications, Inc.	1	4061	0	4115	4115	0.9868772782503038	perston-publications-inc
+Pesticide Science Society of Japan/Nippon Noyaku Gakkai	1	144	3275	3275	3275	0.04396946564885496	pesticide-science-society-of-japan-nippon-noyaku-gakkai
+Peter Lang AG	1	133	0	0	378	0.35185185185185186	peter-lang-ag
+Peter Peregrinus, Ltd.	1	1276	0	0	1276	1.0	peter-peregrinus-ltd
+Peter the Great St.-Petersburg Polytechnic University	1	1	0	417	417	0.002398081534772182	peter-the-great-st-petersburg-polytechnic-university
+Petrozavodsk State University	1	0	0	48	48	0.0	petrozavodsk-state-university
+Pharmaceutical Press	1	201	0	0	225	0.8933333333333333	pharmaceutical-press
+Pharmaceutical Products Press	4	50	0	0	354	0.14124293785310735	pharmaceutical-products-press
+Pharmaceutical Society of Japan	6	43237	0	38135	43537	0.9931093093231045	pharmaceutical-society-of-japan
+Pharmaceutical Society of Korea	1	4908	0	4914	4914	0.9987789987789988	pharmaceutical-society-of-korea
+Pharmacognosy Network Worldwide	1	491	0	683	683	0.718887262079063	pharmacognosy-network-worldwide
+Pharmamed Mado Ltd.	1	0	0	349	349	0.0	pharmamed-mado-ltd
+Philippine College of Physicians	1	0	0	35	35	0.0	philippine-college-of-physicians
+Philips Research Laboratories	1	94	0	0	94	1.0	philips-research-laboratories
+Philosophy Documentation Center	14	622	0	18512	19234	0.03233856712072372	philosophy-documentation-center
+Philosophy Documentation Center, Saint Louis University	1	0	0	171	171	0.0	philosophy-documentation-center-saint-louis-university
+Philosophy Education Society, Inc.	1	0	0	2234	2234	0.0	philosophy-education-society-inc
+Photonics Society of Poland	1	1	429	429	429	0.002331002331002331	photonics-society-of-poland
+Physica-Verlag Gmbh und Co.	5	2264	0	2145	4134	0.5476536042573779	physica-verlag-gmbh-und-co
+Physical Therapy Association	1	0	0	25	25	0.0	physical-therapy-association
+Physicians Postgraduate Press Inc.	3	41	0	6965	7734	0.00530126713214378	physicians-postgraduate-press-inc
+Physics Essays Publication	1	505	0	2065	2065	0.24455205811138014	physics-essays-publication
+Physiological Society of Japan	1	0	0	0	3481	0.0	physiological-society-of-japan
+Physiological Society of Nigeria	1	0	0	134	134	0.0	physiological-society-of-nigeria
+PI-ME Tipografia Editrice srl	1	0	0	738	738	0.0	pi-me-tipografia-editrice-srl
+Picard	1	0	0	0	2356	0.0	picard
+Pion Ltd.	3	4244	1062	5294	5294	0.8016622591613147	pion-ltd
+Pitagora editrice	1	163	0	0	163	1.0	pitagora-editrice
+PJD Publications Ltd.	1	0	0	305	305	0.0	pjd-publications-ltd
+Plankton Society of Japan: Japanese Association of Benthology	1	1	0	292	292	0.003424657534246575	plankton-society-of-japan-japanese-association-of-benthology
+Plant Management Network	2	8	0	837	837	0.009557945041816009	plant-management-network
+Polibijaus Fondas	1	0	0	65	65	0.0	polibijaus-fondas
+Police Geological Institute	2	1	0	440	440	0.0022727272727272726	police-geological-institute
+Polish Academy of Sciences	3	338	410	651	651	0.5192012288786483	polish-academy-of-sciences
+Polish Botanical Society	3	1	2794	2973	2973	3.363605785401951e-4	polish-botanical-society
+Polish Chitin Society	1	0	0	69	69	0.0	polish-chitin-society
+Polish Maintenance Society	1	2	0	200	200	0.01	polish-maintenance-society
+Polish Neurological Society	1	678	0	688	688	0.9854651162790697	polish-neurological-society
+Polish Scientific Publishers PWN	2	385	197	456	456	0.8442982456140351	polish-scientific-publishers-pwn
+Polish Society of Food Technologists	1	0	0	596	596	0.0	polish-society-of-food-technologists
+Politique Africaine	1	3	0	0	896	0.0033482142857142855	politique-africaine
+Poljoprivredni Fakultet Osijek	1	0	108	108	108	0.0	poljoprivredni-fakultet-osijek
+Polska Akademia Nauk	21	4073	1642	16939	19506	0.20880754639598073	polska-akademia-nauk
+Polska Akademia Nauk,Instytut Matematycznys	1	14	0	911	911	0.015367727771679473	polska-akademia-nauk-instytut-matematycznys
+Polskie Towarzystwo Biochemiczne	1	0	269	269	269	0.0	polskie-towarzystwo-biochemiczne
+Polskie Towarzystwo Botaniczne/Polish Botanical Society	1	0	40	40	40	0.0	polskie-towarzystwo-botaniczne-polish-botanical-society
+Polskie Towarzystwo Inzynierii Ekologicznej	1	2	399	399	399	0.005012531328320802	polskie-towarzystwo-inzynierii-ekologicznej
+Polskie Towarzystwo Lekarskie, Oddzial Regionalny w Olsztynie, Okregowa Warminsko-Mazurska Izba Lekarska	1	257	0	266	266	0.9661654135338346	polskie-towarzystwo-lekarskie-oddzial-regionalny-w-olsztynie-okregowa-warminsko-mazurska-izba-lekarska
+Polskie Towarzystwo Magnezologiczne	1	2	0	663	663	0.0030165912518853697	polskie-towarzystwo-magnezologiczne
+Polskie Towarzystwo Mikrobiologow/Polish Society of Microbiologists	1	0	0	74	74	0.0	polskie-towarzystwo-mikrobiologow-polish-society-of-microbiologists
+Polskie towarzystwo Psychiatryczne	3	8	468	468	468	0.017094017094017096	polskie-towarzystwo-psychiatryczne
+Polymer Society of Korea	2	2137	0	2809	2809	0.7607689569241723	polymer-society-of-korea
+Pomorski Uniwersytet Medyczny w Szczecinie	1	0	0	83	83	0.0	pomorski-uniwersytet-medyczny-w-szczecinie
+Pontifica Universidad Catolica del Peru/Departamento de Humanidades, Peru	1	0	0	9	9	0.0	pontifica-universidad-catolica-del-peru-departamento-de-humanidades-peru
+Pontifical Institute of Mediaeval Studies	1	1059	0	1059	1059	1.0	pontifical-institute-of-mediaeval-studies
+Pontificia Universidad Catolica de Chile	9	10	2312	2376	2539	0.003938558487593541	pontificia-universidad-catolica-de-chile
+Pontificia Universidad Católica de Valparaíso	4	231	1119	2082	2082	0.11095100864553314	pontificia-universidad-catolica-de-valparaiso
+Pontificia Universidad Catolica del Peru	1	0	30	30	30	0.0	pontificia-universidad-catolica-del-peru
+Pontificia Universidad Javeriana	12	161	834	1179	1179	0.13655640373197625	pontificia-universidad-javeriana
+Pontificia Universidade Catolica	1	0	490	490	490	0.0	pontificia-universidade-catolica
+Pontificia Universidade Catolica de Campinas	3	0	317	317	317	0.0	pontificia-universidade-catolica-de-campinas
+Pontificia Universidade Catolica de Sao Paulo	1	0	596	596	596	0.0	pontificia-universidade-catolica-de-sao-paulo
+Pontificia Universidade Catolica do Rio de Janeiro	1	0	364	364	364	0.0	pontificia-universidade-catolica-do-rio-de-janeiro
+Pontificia Universidade Catolica do Rio Grande do Sul	1	0	94	94	94	0.0	pontificia-universidade-catolica-do-rio-grande-do-sul
+Pontificia Universidade Catolica Parana	1	0	212	212	212	0.0	pontificia-universidade-catolica-parana
+Pontificio Seminario Mayor San Rafael	1	0	134	134	134	0.0	pontificio-seminario-mayor-san-rafael
+Poracom Academic Publishers	1	0	0	0	106	0.0	poracom-academic-publishers
+Portland Press, Ltd.	5	103788	232	105204	105204	0.9865404357248774	portland-press-ltd
+Porto Alegre Sociedade De Psiquiatria Do Rio Grande Do Sul	1	3	0	0	378	0.007936507936507936	porto-alegre-sociedade-de-psiquiatria-do-rio-grande-do-sul
+Portuguese Electrochemical Society	1	10	621	621	621	0.01610305958132045	portuguese-electrochemical-society
+Portuguese Wildlife Society	1	3	160	160	160	0.01875	portuguese-wildlife-society
+Potato Association of America	1	6180	0	0	6180	1.0	potato-association-of-america
+Practical Action Publishing	1	141	0	330	330	0.42727272727272725	practical-action-publishing
+Prague Development Center	1	0	135	135	135	0.0	prague-development-center
+Praise Worthy Prize	8	0	0	1051	1418	0.0	praise-worthy-prize
+Precast - Prestressed Concrete Institute	1	0	0	1589	1589	0.0	precast-prestressed-concrete-institute
+Prensa Medica Argentina s.r.l.	1	1	0	120	120	0.008333333333333333	prensa-medica-argentina-s-r-l
+Press of Acta Aeronautica et Astronautica Sinica	1	1610	1636	1636	1636	0.9841075794621027	press-of-acta-aeronautica-et-astronautica-sinica
+Presses de l'Universite de Montreal	4	4749	0	5061	7496	0.633537886872999	presses-de-luniversite-de-montreal
+Presses de l'Universite du Quebec a Montreal	1	1442	0	0	2364	0.6099830795262268	presses-de-luniversite-du-quebec-a-montreal
+Presses de Sciences Po	7	8744	0	18547	18547	0.4714509085027228	presses-de-sciences-po
+Presses Universitaires de France	23	211	522	16735	18894	0.011167566423203133	presses-universitaires-de-france
+Presses Universitaires de Provence	1	6	0	1424	1424	0.004213483146067416	presses-universitaires-de-provence
+Presses Universitaires de Rennes	1	2	0	1463	1463	0.001367053998632946	presses-universitaires-de-rennes
+Presses universitaires de Vincennes	1	0	0	103	103	0.0	presses-universitaires-de-vincennes
+Presses Universitaires du Mirail	4	2	659	1865	1865	0.0010723860589812334	presses-universitaires-du-mirail
+Presses Universitaires Franc-Comtoises	1	17	0	1253	1253	0.013567438148443736	presses-universitaires-franc-comtoises
+Primakov National Research Institute	1	0	0	77	77	0.0	primakov-national-research-institute
+Prime National Publishing Corp.	2	0	0	418	418	0.0	prime-national-publishing-corp
+Princeps Editions	1	34	0	0	486	0.06995884773662552	princeps-editions
+Princeton University Press	1	5141	0	5847	5847	0.879254318453908	princeton-university-press
+Pro Pharma Communications International	1	0	0	253	253	0.0	pro-pharma-communications-international
+Pro-Fono Produtos Especializados para Fonoaudiologia Ltda.	1	0	0	0	319	0.0	pro-fono-produtos-especializados-para-fonoaudiologia-ltda
+Procter & Gamble Co.	1	11	0	987	987	0.011144883485309016	procter-gamble-co
+Professional Books	1	207	0	0	207	1.0	professional-books
+Professional Engineering Publishing Ltd.	2	7443	0	0	7723	0.9637446588113427	professional-engineering-publishing-ltd
+Professional Medical Publications	1	282	1315	1315	1315	0.21444866920152092	professional-medical-publications
+Progress IPS LLC	1	0	0	0	135	0.0	progress-ips-llc
+Project Hope	1	8535	0	8781	8781	0.97198496754356	project-hope
+Proteomass Scientific Society	1	0	0	113	113	0.0	proteomass-scientific-society
+Prous Science	3	12	0	6067	6871	0.0017464706738466017	prous-science
+Psychologia Society	1	0	0	344	344	0.0	psychologia-society
+Psychological Society of Ireland	1	864	0	867	867	0.9965397923875432	psychological-society-of-ireland
+Psychonomic Society Inc.	7	22171	0	0	22171	1.0	psychonomic-society-inc
+PsychOpen	2	1	181	309	309	0.003236245954692557	psychopen
+Public Health Agency of Canada	1	0	62	62	62	0.0	public-health-agency-of-canada
+Public Health Association of Australia	1	473	0	0	473	1.0	public-health-association-of-australia
+Public Library of Science	9	26134	209274	209874	209942	0.12448199979041831	public-library-of-science
+Publicaciones Tecnicas Mediterraneo	1	6	0	1695	1695	0.0035398230088495575	publicaciones-tecnicas-mediterraneo
+Publication Committee for the Tokyo Journal of Mathematics	1	101	0	1332	1332	0.07582582582582582	publication-committee-for-the-tokyo-journal-of-mathematics
+Publimpacto	1	48	480	480	480	0.1	publimpacto
+Publishing House of the Warsaw University of Technology	1	0	0	230	230	0.0	publishing-house-of-the-warsaw-university-of-technology
+Pulsus Group Inc.	3	1	0	771	4156	2.4061597690086623e-4	pulsus-group-inc
+Purdue University Press	5	442	1252	4913	4913	0.08996539792387544	purdue-university-press
+Pushpa Publishing House	6	0	0	1065	1065	0.0	pushpa-publishing-house
+Qiangjiguang Yu Lizishu	1	0	0	3923	3923	0.0	qiangjiguang-yu-lizishu
+Quadrant HealthCom	2	725	0	1432	1432	0.5062849162011173	quadrant-healthcom
+Quadrature	1	0	0	50	50	0.0	quadrature
+Quality Review Center, Joint Commission on Accreditation of Hospitals	1	737	0	0	737	1.0	quality-review-center-joint-commission-on-accreditation-of-hospitals
+Queensland Museum	1	0	0	22	22	0.0	queensland-museum
+Queensland University of Technology	2	0	539	539	539	0.0	queensland-university-of-technology
+Quintessence Publishing Company	6	1320	0	1738	1789	0.737842370039128	quintessence-publishing-company
+R I L E M Publications S. A. R. L.	1	1928	0	0	1928	1.0	r-i-l-e-m-publications-s-a-r-l
+R.G. Badger	1	248	0	0	273	0.9084249084249084	r-g-badger
+R.K. Sharma, Institute of Medico-Legal Publications	1	0	0	1018	1018	0.0	r-k-sharma-institute-of-medico-legal-publications
+Rabbinical Council of America	1	11	0	0	11	1.0	rabbinical-council-of-america
+Radiation Medicine Association	1	310	0	0	310	1.0	radiation-medicine-association
+Radiation Research Society	1	11701	0	11761	11761	0.994898392993793	radiation-research-society
+Radiological Societies of Denmark Finland Norway and Sweden	2	370	0	0	852	0.43427230046948356	radiological-societies-of-denmark-finland-norway-and-sweden
+Radiological Society of North America	1	34385	0	56339	56339	0.6103232219244218	radiological-society-of-north-america
+Radiological Society of North America, Inc.	1	4077	0	4855	4855	0.8397528321318228	radiological-society-of-north-america-inc
+Rainer Hampp Verlag	2	0	0	181	181	0.0	rainer-hampp-verlag
+Rajshahi University Zoological Society	1	2	0	0	221	0.00904977375565611	rajshahi-university-zoological-society
+RALK	1	0	0	81	81	0.0	ralk
+Ramon Canto Alcaraz	1	6	292	292	292	0.02054794520547945	ramon-canto-alcaraz
+RAMS Consultants	1	0	0	8	8	0.0	rams-consultants
+Rapid Science Publishers	1	788	0	0	873	0.9026345933562429	rapid-science-publishers
+Raptor Research Foundation, Inc.	1	685	0	689	689	0.9941944847605225	raptor-research-foundation-inc
+Rasayan Journal	1	0	28	28	28	0.0	rasayan-journal
+Raven Press	1	176	0	0	615	0.2861788617886179	raven-press
+Recherches amerindiennes au Quebec	1	169	0	0	366	0.46174863387978143	recherches-amerindiennes-au-quebec
+Redaktsiya Zhurnala Aviakosmicheskaya i Ekologicheskaya Meditsina	1	0	0	42	42	0.0	redaktsiya-zhurnala-aviakosmicheskaya-i-ekologicheskaya-meditsina
+Redprint Editora Ltda.	2	3	751	751	751	0.0039946737683089215	redprint-editora-ltda
+Regional Euro-Asian Biological Invasions Centre	3	25	1178	1178	1178	0.021222410865874362	regional-euro-asian-biological-invasions-centre
+Regional Information Center for Science and Technology	1	0	243	243	243	0.0	regional-information-center-for-science-and-technology
+Regional Institute of Medical Sciences	1	0	0	233	233	0.0	regional-institute-of-medical-sciences
+Rehabilitacja Medyczna	1	0	0	18	18	0.0	rehabilitacja-medyczna
+Research and publications office, Jimma University	1	52	310	310	310	0.16774193548387098	research-and-publications-office-jimma-university
+Research and Science Policy of the University of Valencia	1	0	105	105	105	0.0	research-and-science-policy-of-the-university-of-valencia
+Research Information Ltd.	1	1146	0	1252	1252	0.9153354632587859	research-information-ltd
+Research Institut of Pomology and Floriculture	1	14	17	17	17	0.8235294117647058	research-institut-of-pomology-and-floriculture
+Research Network of Computational and Structural Biotechnology	1	303	311	311	311	0.9742765273311897	research-network-of-computational-and-structural-biotechnology
+Revista Latinoamericana De Psicologia	1	84	112	112	112	0.75	revista-latinoamericana-de-psicologia
+Revue Sante Mentale au Quebec	1	957	0	1561	1561	0.6130685458039719	revue-sante-mentale-au-quebec
+Revus Klub	1	0	0	193	193	0.0	revus-klub
+Rio de Janeiro Botanical Garden	1	18	498	498	498	0.03614457831325301	rio-de-janeiro-botanical-garden
+Rio De Janeiro Rev Y Med, Editora Arte E Ciencia	1	110	194	194	194	0.5670103092783505	rio-de-janeiro-rev-y-med-editora-arte-e-ciencia
+River Publishers	2	0	0	109	109	0.0	river-publishers
+Rockefeller University Press	3	51884	0	57656	57656	0.8998889968086583	rockefeller-university-press
+Rockville Md Public Health Service	1	267	0	0	267	1.0	rockville-md-public-health-service
+Rocky Mountain Mathematics Consortium	2	1220	0	4530	4530	0.2693156732891832	rocky-mountain-mathematics-consortium
+Romatizma Arastirma ve Savas, Dernegi	1	127	0	0	203	0.625615763546798	romatizma-arastirma-ve-savas-dernegi
+Rosenberg & Sellier	2	0	122	181	181	0.0	rosenberg-sellier
+Rosenstiel School of Marine and Atmospheric Science	1	327	0	398	398	0.821608040201005	rosenstiel-school-of-marine-and-atmospheric-science
+Rossiiskaya Akademiya Meditsinskikh Nauk	1	0	0	534	534	0.0	rossiiskaya-akademiya-meditsinskikh-nauk
+Rossiiskaya Ugol'naya Kompaniya Rosugol	1	0	0	217	217	0.0	rossiiskaya-ugolnaya-kompaniya-rosugol
+Rotoweb Cantelli	1	10	481	481	481	0.02079002079002079	rotoweb-cantelli
+Routledge	2	1525	0	0	1526	0.9993446920052425	routledge
+Royal Aeronautical Society	1	11	0	0	814	0.013513513513513514	royal-aeronautical-society
+Royal Anthropological Institute	1	11311	0	0	11311	1.0	royal-anthropological-institute
+Royal Asiatic Society of Great Britain & Ireland	1	1244	0	0	14749	0.08434470133568378	royal-asiatic-society-of-great-britain-ireland
+Royal Astronomical Society by Blackwell Scientific Publications	2	2716	0	0	2716	1.0	royal-astronomical-society-by-blackwell-scientific-publications
+Royal College of General Practitioners	1	955	0	3926	3926	0.24325012735608761	royal-college-of-general-practitioners
+Royal College of Nursing	1	1340	0	0	5090	0.2632612966601179	royal-college-of-nursing
+Royal College of Nursing Publishing Co.	9	44165	0	107055	199180	0.22173410985038658	royal-college-of-nursing-publishing-co
+Royal College of Physicians	1	3239	0	3320	3320	0.9756024096385543	royal-college-of-physicians
+Royal College of Physicians of Edinburgh	1	21	472	472	472	0.04449152542372881	royal-college-of-physicians-of-edinburgh
+Royal College of Psychiatrists	5	7051	0	40296	53113	0.13275469282473218	royal-college-of-psychiatrists
+Royal Institute of Chemistry	1	50	0	0	50	1.0	royal-institute-of-chemistry
+Royal Institution of Naval Architects	2	0	0	137	137	0.0	royal-institution-of-naval-architects
+Royal Irish Academy	5	196	0	991	991	0.1977800201816347	royal-irish-academy
+Royal Netherlands Chemical Society	1	11182	0	0	11182	1.0	royal-netherlands-chemical-society
+Royal Netherlands Pharmaceutical Society	1	1060	0	1060	1060	1.0	royal-netherlands-pharmaceutical-society
+Royal Photographic Society of Great Britain	1	12	0	0	1879	0.006386375731772219	royal-photographic-society-of-great-britain
+Royal Scottish Geographical Society	1	6493	0	0	6508	0.9976951444376152	royal-scottish-geographical-society
+Royal Society for the Promotion of Health	3	14306	0	0	14307	0.9999301041448242	royal-society-for-the-promotion-of-health
+Royal Society of Chemistry	66	382382	0	330478	406837	0.939889931348427	royal-society-of-chemistry
+Royal Society Of Edinburgh.	2	3653	0	0	3822	0.95578231292517	royal-society-of-edinburgh
+Royal Society of Medicine	4	430	0	4813	5224	0.08231240428790199	royal-society-of-medicine
+Royal Society of Queensland	1	0	0	0	23	0.0	royal-society-of-queensland
+Royal Society of Tasmania	1	0	0	0	28	0.0	royal-society-of-tasmania
+Royal Society of Victoria	1	4	0	39	39	0.10256410256410256	royal-society-of-victoria
+Royal Swedish Academy of Sciences	1	2109	0	2199	2199	0.9590723055934516	royal-swedish-academy-of-sciences
+Royal Zoological Society of New South Wales	1	19	0	696	696	0.027298850574712645	royal-zoological-society-of-new-south-wales
+Rudolf M. Rohrer	1	0	0	0	144	0.0	rudolf-m-rohrer
+Russell Palmer	1	512	0	0	512	1.0	russell-palmer
+Russian Academy of Agricultural Sciences	1	4	0	998	998	0.004008016032064128	russian-academy-of-agricultural-sciences
+Russian Academy of Sciences	5	3019	0	3653	4423	0.6825683924937825	russian-academy-of-sciences
+Russian Association of Allergologists and Clinical Immunologists, St. Petersburg Regional Branch (SPb RAACI)	1	0	739	739	739	0.0	russian-association-of-allergologists-and-clinical-immunologists-st-petersburg-regional-branch-spb-raaci
+Russian Electronic Journal of Radiology	1	0	0	49	49	0.0	russian-electronic-journal-of-radiology
+Russian open medical journal	1	23	142	142	142	0.1619718309859155	russian-open-medical-journal
+Russian Presidential Academy of National Economy and Public Administration	1	0	0	40	40	0.0	russian-presidential-academy-of-national-economy-and-public-administration
+Russian Public Opinion Research Center, VCIOM	1	0	0	239	239	0.0	russian-public-opinion-research-center-vciom
+Russian Society of Cardiology	1	0	0	647	647	0.0	russian-society-of-cardiology
+Russian Transplant Society	1	0	282	282	282	0.0	russian-transplant-society
+Rutgers University	2	624	0	82	705	0.8851063829787233	rutgers-university
+S & K Pub.	1	0	0	0	19	0.0	s-k-pub
+S K Press V.O.S.	1	0	75	75	75	0.0	s-k-press-v-o-s
+SA Medical Association Health and Medical Pub. Group	1	5	58	58	58	0.08620689655172414	sa-medical-association-health-and-medical-pub-group
+SAGE	816	1448041	30989	1557777	1593717	0.9085935583293646	sage
+Saint Petersburg Pasteur Institute	1	0	0	244	244	0.0	saint-petersburg-pasteur-institute
+Saint Petersburg State University	2	0	118	118	118	0.0	saint-petersburg-state-university
+Sakarya University	1	0	1	1	1	0.0	sakarya-university
+San Diego State University	1	43	0	44	44	0.9772727272727273	san-diego-state-university
+Sandfield Publications	1	956	0	0	956	1.0	sandfield-publications
+Sapiens Publishing	1	0	0	0	1	0.0	sapiens-publishing
+Saudi Arabian Armed Forces Ministry of Defence and Activation	1	5	0	514	514	0.009727626459143969	saudi-arabian-armed-forces-ministry-of-defence-and-activation
+Savez Ekonomista Vojvodine	1	7	375	375	375	0.018666666666666668	savez-ekonomista-vojvodine
+Savez Hemijskih Inzenjera	1	27	1085	1085	1085	0.02488479262672811	savez-hemijskih-inzenjera
+Savezno Ministarstvo Odbrane	1	732	2449	2449	2449	0.2988975091874234	savezno-ministarstvo-odbrane
+Sax Institute	1	2	129	129	129	0.015503875968992248	sax-institute
+Scandinavian University Press	1	89	0	0	89	1.0	scandinavian-university-press
+Schattauer GmbH	10	732	0	8031	8031	0.09114680612626073	schattauer-gmbh
+Scholars Press	1	0	0	0	3285	0.0	scholars-press
+School Of Biological Anthropology	1	0	44	44	44	0.0	school-of-biological-anthropology
+School of Economics and Business in Sarajevo	1	69	116	116	116	0.5948275862068966	school-of-economics-and-business-in-sarajevo
+School of Humanities and Communication Arts, University of Western Sydney	1	1	43	43	43	0.023255813953488372	school-of-humanities-and-communication-arts-university-of-western-sydney
+School of Management Sciences	1	0	0	10	10	0.0	school-of-management-sciences
+School of Social Work	1	0	0	127	127	0.0	school-of-social-work
+Schweizerbartsche Verlagsbuchhandlung	1	456	0	500	500	0.912	schweizerbartsche-verlagsbuchhandlung
+Schweizerische Chemische Gedellschaft	1	1975	0	2289	2289	0.8628221930974225	schweizerische-chemische-gedellschaft
+Science Alert	3	0	0	0	779	0.0	science-alert
+Science and Education Publishing	1	0	0	100	100	0.0	science-and-education-publishing
+Science and Engineering Research Support Society	11	1231	4867	2909	10638	0.11571724008272231	science-and-engineering-research-support-society
+Science and Technology Letters	3	1058	0	0	1093	0.9679780420860018	science-and-technology-letters
+Science Editors	1	1171	0	0	1311	0.893211289092296	science-editors
+Science House	1	3724	0	0	3754	0.9920085242408098	science-house
+Science Press	41	23823	3130	50353	57877	0.4116142854674569	science-press
+Science Publications	13	76	8311	3150	9278	0.008191420564776892	science-publications
+Science Publishing Corporation Inc	1	0	0	245	245	0.0	science-publishing-corporation-inc
+Science Reviews Ltd.	5	5812	0	4907	5994	0.9696363029696363	science-reviews-ltd
+Science Service	1	38016	0	0	38021	0.9998684937271508	science-service
+SCIENCEDOMAIN international	1	4	686	686	686	0.0058309037900874635	sciencedomain-international
+Sciences Humaines	1	1	0	0	273	0.003663003663003663	sciences-humaines
+Scientechnica Publishers	1	280	0	0	280	1.0	scientechnica-publishers
+Scientific American Inc.	1	22600	0	186473	186473	0.12119717063596339	scientific-american-inc
+Scientific and Technical Press	1	45	0	0	45	1.0	scientific-and-technical-press
+Scientific and Technical research Council of Turkey - TUBITAK/Turkiye Bilimsel ve Teknik Arastirma Kurumu	12	2325	1248	4644	4692	0.4955242966751918	scientific-and-technical-research-council-of-turkey-tubitak-turkiye-bilimsel-ve-teknik-arastirma-kurumu
+Scientific Publishers	2	37	1564	1577	1577	0.023462270133164237	scientific-publishers
+Scientific Society of Szczecin	1	29	1086	1086	1086	0.026703499079189688	scientific-society-of-szczecin
+Scientific.net	1	10280	0	10646	10646	0.9656208904752959	scientific-net
+Scitec Publications Ltd.	2	0	0	0	2972	0.0	scitec-publications-ltd
+Scoala Nationala de Studii Politice Administratice (S.N.S.P.A.)	1	0	69	69	69	0.0	scoala-nationala-de-studii-politice-administratice-s-n-s-p-a
+Scripta Pub Co.	1	0	0	0	73	0.0	scripta-pub-co
+Scripta Technica	2	2539	0	0	2810	0.90355871886121	scripta-technica
+Scrivener Publishing	2	107	0	222	222	0.481981981981982	scrivener-publishing
+Sea Fisheries Research Institute	1	829	0	0	829	1.0	sea-fisheries-research-institute
+Sears Foundation for Marine Research	1	693	0	1237	1237	0.5602263540824576	sears-foundation-for-marine-research
+Second Military Medical University Press	1	0	0	2495	2495	0.0	second-military-medical-university-press
+Secretaria Regional do Rio de Janeiro da Sociedade Brasileira de Quimica	1	0	701	701	701	0.0	secretaria-regional-do-rio-de-janeiro-da-sociedade-brasileira-de-quimica
+Secretariado de Publicaciones e Intercambio Cientifico	1	5	526	526	526	0.009505703422053232	secretariado-de-publicaciones-e-intercambio-cientifico
+SEFA Ltd.	1	321	0	0	321	1.0	sefa-ltd
+Segmento Farma Editores	1	2	244	244	244	0.00819672131147541	segmento-farma-editores
+Seimitsu Kogakkai/The Japan Society for Precision Engineering	1	1	0	9481	9481	1.0547410610695074e-4	seimitsu-kogakkai-the-japan-society-for-precision-engineering
+Seismological Society of America	2	6866	0	7007	7007	0.9798772655915513	seismological-society-of-america
+Seismological Society of China	1	432	444	444	444	0.972972972972973	seismological-society-of-china
+Sejong University	1	2	0	840	840	0.002380952380952381	sejong-university
+Sekiyu Gakkai	1	27	0	0	2238	0.012064343163538873	sekiyu-gakkai
+Seminario Matematico e Fisico di Milano	1	1066	0	0	1066	1.0	seminario-matematico-e-fisico-di-milano
+Seoul Kjo	1	2	0	1294	1294	0.0015455950540958269	seoul-kjo
+Seoul National University	3	3	581	1217	1217	0.0024650780608052587	seoul-national-university
+SEPM Society for Sedimentary Geology	1	3409	0	7523	7523	0.45314369267579424	sepm-society-for-sedimentary-geology
+Serbian Biological Society	1	28	1738	1738	1738	0.01611047180667434	serbian-biological-society
+Serbian Medical Association	1	24	1852	1852	1852	0.012958963282937365	serbian-medical-association
+Serbian Society for Mechanics	1	6	0	262	262	0.022900763358778626	serbian-society-for-mechanics
+Service des publications de l'Universite de Toulouse-Le Mirail	1	0	874	874	874	0.0	service-des-publications-de-luniversite-de-toulouse-le-mirail
+Servicio de Publicaciones de la Universidad De Navarra	5	10	0	202	202	0.04950495049504951	servicio-de-publicaciones-de-la-universidad-de-navarra
+Servicio de Publicaciones de la Universidad Pontificia Comillas	1	0	0	124	124	0.0	servicio-de-publicaciones-de-la-universidad-pontificia-comillas
+Servicio de Publicaciones, Universidad Complutense	1	0	0	85	85	0.0	servicio-de-publicaciones-universidad-complutense
+Servicio de Publicacions da Universidade de Vigo	1	18	0	20	20	0.9	servicio-de-publicacions-da-universidade-de-vigo
+Servicio Editorial De La Universidad Del Pais Vasco	2	49	157	253	253	0.19367588932806323	servicio-editorial-de-la-universidad-del-pais-vasco
+Servicio Nacional de Geologia y Mineria	2	1	232	232	414	0.0024154589371980675	servicio-nacional-de-geologia-y-mineria
+Seville University Press	1	0	0	383	383	0.0	seville-university-press
+SF-TH Inc.	1	529	0	609	609	0.8686371100164204	sf-th-inc
+Shahid Beheshti Medical University	1	0	145	145	145	0.0	shahid-beheshti-medical-university
+Shahid Beheshti University of Medical Sciences	1	3	0	207	207	0.014492753623188406	shahid-beheshti-university-of-medical-sciences
+Shanghai Association of Integrative Medicine	1	1	0	0	1806	5.537098560354374e-4	shanghai-association-of-integrative-medicine
+Shanghai Jiaotong University Press	1	1112	0	1131	1131	0.9832007073386384	shanghai-jiaotong-university-press
+Shanghai Ocean University	1	0	0	665	665	0.0	shanghai-ocean-university
+Shanghai Scientific and Technical Publishers	1	0	0	0	683	0.0	shanghai-scientific-and-technical-publishers
+Shanghai University Press	1	1298	0	0	1298	1.0	shanghai-university-press
+Sharif University of Technology	1	486	0	486	486	1.0	sharif-university-of-technology
+Sheffield Academic Press Ltd	1	66	0	393	393	0.16793893129770993	sheffield-academic-press-ltd
+Shenzhen University	1	0	0	483	483	0.0	shenzhen-university
+Sherborne Gibbs	1	0	0	119	119	0.0	sherborne-gibbs
+Shinku Kyokai	2	0	0	1058	5645	0.0	shinku-kyokai
+Shiraz University of Medical Sciences	1	0	39	39	39	0.0	shiraz-university-of-medical-sciences
+Siauliai University	1	0	6	6	6	0.0	siauliai-university
+Siberian Federal University	1	0	0	159	159	0.0	siberian-federal-university
+Sichuan Society for Biomedical Engineering	1	1515	0	0	1515	1.0	sichuan-society-for-biomedical-engineering
+Sichuan University Press	1	275	279	279	279	0.985663082437276	sichuan-university-press
+Sigma Theta Tau International Honor Society of Nursing	2	290	0	0	290	1.0	sigma-theta-tau-international-honor-society-of-nursing
+Sigma XI	1	3	0	1977	1977	0.0015174506828528073	sigma-xi
+Silvia Tanno	1	0	0	69	69	0.0	silvia-tanno
+Singapore Medical Association	1	4	0	874	874	0.004576659038901602	singapore-medical-association
+Singapore University Press	1	1	0	185	185	0.005405405405405406	singapore-university-press
+Singular Pub. Group	1	262	0	0	262	1.0	singular-pub-group
+SIR Publishing	1	1107	0	0	1107	1.0	sir-publishing
+Sirey	1	1	0	684	684	0.0014619883040935672	sirey
+Sistema Nacional Para El Desarrollo Integral De La Familia	1	0	166	166	166	0.0	sistema-nacional-para-el-desarrollo-integral-de-la-familia
+Sixteenth Century Press	1	8945	0	8945	8945	1.0	sixteenth-century-press
+SkillsClinic Ltd.	1	0	0	0	10	0.0	skillsclinic-ltd
+Slack Incorporated	11	486	0	22376	22376	0.02171969967822667	slack-incorporated
+Slack, Inc.	4	169	0	0	2609	0.06477577615944806	slack-inc
+Slavica Publishers	2	456	0	1183	1183	0.38546069315300086	slavica-publishers
+Slovak Academy of Sciences	2	6	0	159	159	0.03773584905660377	slovak-academy-of-sciences
+Slovak Toxicology Society SETOX	1	202	241	241	241	0.8381742738589212	slovak-toxicology-society-setox
+Slovenian Chemical Society	1	0	115	115	115	0.0	slovenian-chemical-society
+Slovenian Medical Society	1	0	0	62	62	0.0	slovenian-medical-society
+Slovenian Psychologists' Association	1	0	67	67	67	0.0	slovenian-psychologists-association
+Slovenian Society for Stereology and Quantitative Image Analysis	1	82	390	390	390	0.21025641025641026	slovenian-society-for-stereology-and-quantitative-image-analysis
+Slovenska Akademia Vied	2	7	0	331	331	0.021148036253776436	slovenska-akademia-vied
+Slovenska Technika Univerzita	1	157	0	237	237	0.6624472573839663	slovenska-technika-univerzita
+Slovenska Vzdelavacia a Obstaravacia s.r.o	1	0	85	85	85	0.0	slovenska-vzdelavacia-a-obstaravacia-s-r-o
+Smithsonian Magazine	1	0	0	41	41	0.0	smithsonian-magazine
+Smithsonian Press	1	0	0	672	672	0.0	smithsonian-press
+Socidrogalcohol	1	0	0	761	761	0.0	socidrogalcohol
+Sociedad Argentina De Cardiologia	1	0	577	577	577	0.0	sociedad-argentina-de-cardiologia
+Sociedad Argentina de Endocrinologia y Metabolismo	1	30	34	0	34	0.8823529411764706	sociedad-argentina-de-endocrinologia-y-metabolismo
+Sociedad Botanica de Mexico	1	0	566	566	566	0.0	sociedad-botanica-de-mexico
+Sociedad Brasileira De Cardiologia	2	122	3940	4195	4195	0.029082240762812874	sociedad-brasileira-de-cardiologia
+Sociedad Chilena de Anatomia	1	4	2384	2384	2384	0.0016778523489932886	sociedad-chilena-de-anatomia
+Sociedad Chilena de la Ciencia del Suelo	2	10	439	439	524	0.019083969465648856	sociedad-chilena-de-la-ciencia-del-suelo
+Sociedad Chilena de Nutricion, Bromatologia, Toxicologia	1	2	680	680	680	0.0029411764705882353	sociedad-chilena-de-nutricion-bromatologia-toxicologia
+Sociedad Chilena de Obstetricia y Ginecologia	1	3	1254	1254	1254	0.0023923444976076554	sociedad-chilena-de-obstetricia-y-ginecologia
+Sociedad Chilena de Parasitologia	1	0	0	0	69	0.0	sociedad-chilena-de-parasitologia
+Sociedad Chilena de Pediatria	1	215	3785	3785	3785	0.05680317040951123	sociedad-chilena-de-pediatria
+Sociedad Chilena De Quimica	2	8	1341	1341	1591	0.00502828409805154	sociedad-chilena-de-quimica
+Sociedad Colombiana De Cardiologia	1	653	0	673	673	0.9702823179791976	sociedad-colombiana-de-cardiologia
+Sociedad Colombiana De Obstetricia y Ginecologia	1	0	0	111	111	0.0	sociedad-colombiana-de-obstetricia-y-ginecologia
+Sociedad de Biologia de Chile	1	73	832	832	832	0.08774038461538461	sociedad-de-biologia-de-chile
+Sociedad de Ciencias Aranzadi Research Centre	1	0	67	67	67	0.0	sociedad-de-ciencias-aranzadi-research-centre
+Sociedad de estadistica e investigacion operativa	3	864	0	0	864	1.0	sociedad-de-estadistica-e-investigacion-operativa
+Sociedad Espanola de Ceramica y Vidrio	1	89	0	1100	1100	0.0809090909090909	sociedad-espanola-de-ceramica-y-vidrio
+Sociedad Espanola de Cirurgia Plastica	1	0	511	511	511	0.0	sociedad-espanola-de-cirurgia-plastica
+Sociedad Espanola de Enfermeria Nefrologica	2	0	266	522	522	0.0	sociedad-espanola-de-enfermeria-nefrologica
+Sociedad Espanola de Investigacion Osea y del Metabolismo Mineral	1	0	0	78	78	0.0	sociedad-espanola-de-investigacion-osea-y-del-metabolismo-mineral
+Sociedad Espanola de Microbiologia	1	91	91	91	91	1.0	sociedad-espanola-de-microbiologia
+Sociedad Espanola de Neurocirugia	1	1805	0	2173	2173	0.8306488725264611	sociedad-espanola-de-neurocirugia
+Sociedad Espanola de Ornitologia	1	208	0	216	216	0.9629629629629629	sociedad-espanola-de-ornitologia
+Sociedad Espanola de Pedagogia	1	0	0	184	184	0.0	sociedad-espanola-de-pedagogia
+Sociedad Espanola Inmunologia	1	181	0	0	181	1.0	sociedad-espanola-inmunologia
+Sociedad Espanola para el Estudio de la Ansiedad y el Estres	1	20	0	22	22	0.9090909090909091	sociedad-espanola-para-el-estudio-de-la-ansiedad-y-el-estres
+Sociedad Medica de Santiago	1	6	4067	4067	4067	0.0014752889107450208	sociedad-medica-de-santiago
+Sociedad Mexicana de Ingenieria Biomedica	1	0	0	39	39	0.0	sociedad-mexicana-de-ingenieria-biomedica
+Sociedade Botanica do Brasil	1	30	1474	1474	1474	0.0203527815468114	sociedade-botanica-do-brasil
+Sociedade Brasileira de Angiologia e Cirurgia Vascular	1	80	743	743	743	0.10767160161507403	sociedade-brasileira-de-angiologia-e-cirurgia-vascular
+Sociedade Brasileira de Automatica	1	1	0	0	508	0.001968503937007874	sociedade-brasileira-de-automatica
+Sociedade Brasileira de Ciencia do Solo	1	15	2613	2613	2613	0.0057405281285878304	sociedade-brasileira-de-ciencia-do-solo
+Sociedade Brasileira de Ciencia e Tecnologia de Alimentos	1	35	2487	2487	2487	0.01407318053880177	sociedade-brasileira-de-ciencia-e-tecnologia-de-alimentos
+Sociedade Brasileira de Cirurgia Cardiovascular	1	10	2013	2013	2013	0.004967709885742673	sociedade-brasileira-de-cirurgia-cardiovascular
+Sociedade Brasileira de Coloproctologia	1	201	229	229	229	0.8777292576419214	sociedade-brasileira-de-coloproctologia
+Sociedade Brasileira de Dermatologia	2	1	1591	1591	1591	6.285355122564425e-4	sociedade-brasileira-de-dermatologia
+Sociedade Brasileira de Engenharia Agricola	1	3	1077	1077	1077	0.002785515320334262	sociedade-brasileira-de-engenharia-agricola
+Sociedade Brasileira de Engenharia Biomedica	2	2	0	88	241	0.008298755186721992	sociedade-brasileira-de-engenharia-biomedica
+Sociedade Brasileira de Entomologia	1	139	265	265	265	0.5245283018867924	sociedade-brasileira-de-entomologia
+Sociedade Brasileira de Farmacognosia	1	519	1804	1804	1804	0.2876940133037694	sociedade-brasileira-de-farmacognosia
+Sociedade Brasileira de Fisica	1	0	10	10	10	0.0	sociedade-brasileira-de-fisica
+Sociedade Brasileira de Fisiological Vegetal	1	0	0	0	48	0.0	sociedade-brasileira-de-fisiological-vegetal
+Sociedade Brasileira de Fitopatologia	1	2	0	0	804	0.0024875621890547263	sociedade-brasileira-de-fitopatologia
+Sociedade Brasileira de Fruticultura	1	6	162	162	162	0.037037037037037035	sociedade-brasileira-de-fruticultura
+Sociedade Brasileira de Genetica	2	16	2025	2025	2164	0.0073937153419593345	sociedade-brasileira-de-genetica
+Sociedade Brasileira de Geologia	2	0	193	193	256	0.0	sociedade-brasileira-de-geologia
+Sociedade Brasileira de Geotisica	1	3	0	949	949	0.003161222339304531	sociedade-brasileira-de-geotisica
+Sociedade Brasileira de Herbicidas e Ervas Daninhas	1	6	1665	1665	1665	0.0036036036036036037	sociedade-brasileira-de-herbicidas-e-ervas-daninhas
+Sociedade Brasileira de Herpetologia	1	306	0	306	306	1.0	sociedade-brasileira-de-herpetologia
+Sociedade Brasileira de Ictiologia	1	8	668	668	668	0.011976047904191617	sociedade-brasileira-de-ictiologia
+Sociedade Brasileira de Matematica	1	3	396	396	396	0.007575757575757576	sociedade-brasileira-de-matematica
+Sociedade Brasileira de Medicina Tropical	1	14	334	334	334	0.041916167664670656	sociedade-brasileira-de-medicina-tropical
+Sociedade Brasileira de Meteorologia	1	0	47	47	47	0.0	sociedade-brasileira-de-meteorologia
+Sociedade Brasileira de Oftalmologia	1	1	275	275	275	0.0036363636363636364	sociedade-brasileira-de-oftalmologia
+Sociedade Brasileira de Otorrinolaringologia	1	0	0	0	1091	0.0	sociedade-brasileira-de-otorrinolaringologia
+Sociedade Brasileira de Paleontologia	1	18	392	392	392	0.04591836734693878	sociedade-brasileira-de-paleontologia
+Sociedade Brasileira de Patologia Clinica	1	3	971	971	971	0.003089598352214212	sociedade-brasileira-de-patologia-clinica
+Sociedade Brasileira de Pesquisa Operacional	1	5	413	413	413	0.012106537530266344	sociedade-brasileira-de-pesquisa-operacional
+Sociedade Brasileira de Pneumologia e Tisiologia	2	9	1816	1816	2136	0.004213483146067416	sociedade-brasileira-de-pneumologia-e-tisiologia
+Sociedade Brasileira de Psicologia	1	2	0	371	371	0.005390835579514825	sociedade-brasileira-de-psicologia
+Sociedade Brasileira de Quimica	1	43	4895	4895	4895	0.008784473953013279	sociedade-brasileira-de-quimica
+Sociedade Brasileira de Zoologia	2	41	716	716	2994	0.013694054776219105	sociedade-brasileira-de-zoologia
+Sociedade Brasileira para o Desenvolvimento de Pesquisa em Cirurgia	1	0	554	554	554	0.0	sociedade-brasileira-para-o-desenvolvimento-de-pesquisa-em-cirurgia
+Sociedade Brasileria de Fonoaudiologia	1	0	0	0	147	0.0	sociedade-brasileria-de-fonoaudiologia
+Sociedade Braslleira de Microbiologia/Brazilian Society for Microbiology	1	1	0	0	97	0.010309278350515464	sociedade-braslleira-de-microbiologia-brazilian-society-for-microbiology
+Sociedade Braslleira de Quirnica	1	84	4702	4702	4702	0.01786473840918758	sociedade-braslleira-de-quirnica
+Sociedade de Investigacoes Florestais, Universidade Federal de Vicosa	1	8	1428	1428	1428	0.0056022408963585435	sociedade-de-investigacoes-florestais-universidade-federal-de-vicosa
+Sociedade de Olericultura do Brasil	1	8	1784	1784	1784	0.004484304932735426	sociedade-de-olericultura-do-brasil
+Sociedade De Pediatria De Sao Paulo	1	187	288	288	288	0.6493055555555556	sociedade-de-pediatria-de-sao-paulo
+Sociedade Portuguesa de Angiologia e Cirurgia Vascular	1	179	0	183	183	0.9781420765027322	sociedade-portuguesa-de-angiologia-e-cirurgia-vascular
+Sociedade Portuguesa De Cardiologia	1	972	0	1005	1005	0.9671641791044776	sociedade-portuguesa-de-cardiologia
+Sociedade Portuguesa de Pneumologia	1	1464	0	1525	1525	0.96	sociedade-portuguesa-de-pneumologia
+Societa Botanica Italiana	1	2915	0	0	2920	0.9982876712328768	societa-botanica-italiana
+Societa chimica italiana	1	441	0	0	441	1.0	societa-chimica-italiana
+Societa Geologica Italiana	2	82	0	695	695	0.11798561151079137	societa-geologica-italiana
+Societa Italiana di Fisica	2	11720	0	21	11720	1.0	societa-italiana-di-fisica
+Societa Speleologica Italiana	1	99	753	753	753	0.13147410358565736	societa-speleologica-italiana
+Societat Catalana de Seguretat i Medicina del Treball (SCSMT)	1	0	0	0	105	0.0	societat-catalana-de-seguretat-i-medicina-del-treball-scsmt
+Societe Blege de Psychologie	1	1	181	181	181	0.0055248618784530384	societe-blege-de-psychologie
+Societe Botanique de France	1	613	0	0	613	1.0	societe-botanique-de-france
+Societe d ' Histoire de la Pharmacie	1	5	1720	1720	1720	0.0029069767441860465	societe-d-histoire-de-la-pharmacie
+Societe d Histoire de la Revolution de 1848 et des Revolutions du XIXe Siecle	1	0	0	582	582	0.0	societe-d-histoire-de-la-revolution-de-1848-et-des-revolutions-du-xixe-siecle
+Societe de Biologie	1	65	0	0	205	0.3170731707317073	societe-de-biologie
+Societe de Protection des Plantes du Quebac/Quebac Society for the Protection of Plants	1	313	0	0	483	0.6480331262939959	societe-de-protection-des-plantes-du-quebac-quebac-society-for-the-protection-of-plants
+Societe des Americanistes	1	0	0	1300	1300	0.0	societe-des-americanistes
+Societe des Amis de la Bibliotheque Salomon Reinach	1	0	0	347	347	0.0	societe-des-amis-de-la-bibliotheque-salomon-reinach
+Societe des antiquaires de Picardie	1	0	0	0	753	0.0	societe-des-antiquaires-de-picardie
+Societe des Bollandistes	1	177	0	2667	2667	0.06636670416197975	societe-des-bollandistes
+Societe Edition Association d'enseignement medical des hopitaux de Paris	1	670	0	0	670	1.0	societe-edition-association-denseignement-medical-des-hopitaux-de-paris
+Societe Francaise d'Archeologie	1	0	0	1885	1885	0.0	societe-francaise-darcheologie
+Societe Francaise d'Etude du Dix-Huitieme Siecle	1	0	0	1585	1585	0.0	societe-francaise-detude-du-dix-huitieme-siecle
+Societe Francaise d'histoire d'outre-mer	2	0	0	370	1111	0.0	societe-francaise-dhistoire-doutre-mer
+Societe Francaise d'Histoire Urbaine	1	7	483	483	483	0.014492753623188406	societe-francaise-dhistoire-urbaine
+Societe Francaise de Musicologie	1	3740	0	3740	3740	1.0	societe-francaise-de-musicologie
+Societe Francaise de Numismatique	1	3	0	882	882	0.003401360544217687	societe-francaise-de-numismatique
+Societe Francaise De Physique	2	105	0	0	6189	0.016965584100824042	societe-francaise-de-physique
+Societe Francaise de Sante Publique	1	6	0	558	558	0.010752688172043012	societe-francaise-de-sante-publique
+Societe Geologique de France	1	1786	0	2639	2639	0.6767715043577113	societe-geologique-de-france
+Societe linneenne de Lyon	1	0	0	3056	3056	0.0	societe-linneenne-de-lyon
+Societe Mathematique de France	1	0	0	2728	2728	0.0	societe-mathematique-de-france
+Societe Prehistorique Francaise	1	3	0	6216	6216	4.8262548262548264e-4	societe-prehistorique-francaise
+Societe Zoologique de France	1	0	0	0	107	0.0	societe-zoologique-de-france
+Societies Of Medical Radiology In Denmark, Finland, Norway And Sweden	1	171	0	0	497	0.3440643863179074	societies-of-medical-radiology-in-denmark-finland-norway-and-sweden
+Society for Analytical Chemistry	1	371	0	0	371	1.0	society-for-analytical-chemistry
+Society for Antibacterial and Antifungal Agents	1	496	0	515	515	0.9631067961165048	society-for-antibacterial-and-antifungal-agents
+Society for Applied Anthropology	1	3201	0	3225	3225	0.9925581395348837	society-for-applied-anthropology
+Society for Asian Music	1	605	0	0	605	1.0	society-for-asian-music
+Society for Biomedical Diabetes Research	1	17	0	340	340	0.05	society-for-biomedical-diabetes-research
+Society for Chaos Theory in Psychology & Life Sciences	1	162	0	162	162	1.0	society-for-chaos-theory-in-psychology-life-sciences
+Society for Computer Simulation	1	1	0	0	1	1.0	society-for-computer-simulation
+Society for Experimental Biology and Medicine	1	127	0	0	431	0.29466357308584684	society-for-experimental-biology-and-medicine
+Society for Experimental Stroke	1	0	40	0	40	0.0	society-for-experimental-stroke
+Society for General Microbiology	5	40905	0	45577	53113	0.7701504339803814	society-for-general-microbiology
+Society for Historians of the Early American Republic	1	2392	0	2392	2392	1.0	society-for-historians-of-the-early-american-republic
+Society for Historical Archaeology	1	91	0	1483	1483	0.06136210384356035	society-for-historical-archaeology
+Society for Imaging Science and Technology	1	576	0	690	690	0.8347826086956521	society-for-imaging-science-and-technology
+Society for In Vitro Biology	1	1319	0	0	1319	1.0	society-for-in-vitro-biology
+Society for Industrial and Applied Mathematics	14	44269	0	44158	44678	0.9908456063386902	society-for-industrial-and-applied-mathematics
+Society for Industrial and Applied Mathematics Publications	1	245	0	247	247	0.9919028340080972	society-for-industrial-and-applied-mathematics-publications
+Society for Integrative and Comparative Biology	1	3571	0	0	3573	0.9994402462916316	society-for-integrative-and-comparative-biology
+Society for japanese Studies	1	1565	0	2412	2412	0.6488391376451078	society-for-japanese-studies
+Society for Longitudinal and Life Course Studies	1	0	0	197	197	0.0	society-for-longitudinal-and-life-course-studies
+Society for Medical Anthropology	1	877	0	0	1199	0.731442869057548	society-for-medical-anthropology
+Society for Neuroscience	2	20382	0	20741	20741	0.982691287787474	society-for-neuroscience
+Society for Northwestern Vertebrate Biology	1	679	0	0	696	0.9755747126436781	society-for-northwestern-vertebrate-biology
+Society for Personality Research	1	2916	0	3032	3032	0.9617414248021108	society-for-personality-research
+Society for Projective Techniques and Personality Assessment	1	748	0	0	750	0.9973333333333333	society-for-projective-techniques-and-personality-assessment
+Society for Projective Techniques and Rorschach Institute	2	924	0	0	944	0.9788135593220338	society-for-projective-techniques-and-rorschach-institute
+Society for Psychotherapy Research (SPR - Italia)	1	0	100	100	100	0.0	society-for-psychotherapy-research-spr-italia
+Society for Range Management	1	6558	0	0	7057	0.9292900666005385	society-for-range-management
+Society for Reproduction and Fertility	2	245	0	0	387	0.6330749354005168	society-for-reproduction-and-fertility
+Society for Song, Yuan, and Conquest Dynasties Studies	1	50	0	110	110	0.45454545454545453	society-for-song-yuan-and-conquest-dynasties-studies
+Society for the Scientific Study of Sexuality	1	9	0	0	9	1.0	society-for-the-scientific-study-of-sexuality
+Society for the Study of Amphibians and Reptiles	1	4470	0	4480	4480	0.9977678571428571	society-for-the-study-of-amphibians-and-reptiles
+Society for the Study of Mediaeval Languages and Literature	1	222	0	5798	5798	0.03828906519489479	society-for-the-study-of-mediaeval-languages-and-literature
+Society for the Study of Reproduction	1	13680	0	19045	19045	0.718298766080336	society-for-the-study-of-reproduction
+Society for the Study of Social Biology	1	669	0	0	669	1.0	society-for-the-study-of-social-biology
+Society for the Study of the Multi-Ethnic Literature of the United States	1	2271	0	2326	2326	0.976354256233878	society-for-the-study-of-the-multi-ethnic-literature-of-the-united-states
+Society for Translational Medicine (STM)	1	0	0	105	105	0.0	society-for-translational-medicine-stm
+Society for Values in Higher Education	1	149	0	161	161	0.9254658385093167	society-for-values-in-higher-education
+Society of Agricultural Meteorology of Japan/Nihon Nogyo Kisho Gakkai	1	0	0	2904	2904	0.0	society-of-agricultural-meteorology-of-japan-nihon-nogyo-kisho-gakkai
+Society of American Archivists	1	0	0	2869	2869	0.0	society-of-american-archivists
+Society of American Foresters	5	809	0	939	1093	0.7401646843549863	society-of-american-foresters
+Society of Anthropology of Knowledge	1	14	361	361	361	0.038781163434903045	society-of-anthropology-of-knowledge
+Society of Archivists	1	1428	0	0	1431	0.9979035639412998	society-of-archivists
+Society of Automotive Engineers	3	53	0	842	842	0.06294536817102138	society-of-automotive-engineers
+Society of Biblical Literature and Exegesis	1	9094	0	9279	9279	0.9800625067356397	society-of-biblical-literature-and-exegesis
+Society of Chemical Engineers Japan	2	7223	0	11790	11790	0.612637828668363	society-of-chemical-engineers-japan
+Society of Chemical Industry	1	1859	0	0	1859	1.0	society-of-chemical-industry
+Society of Diabetic Nephropathy Prevention	1	4	99	99	99	0.04040404040404041	society-of-diabetic-nephropathy-prevention
+Society of Dyers and Colourists	2	5936	0	0	5939	0.9994948644552955	society-of-dyers-and-colourists
+Society of Economic Paleontologists and Mineralogists	1	1938	0	2161	2161	0.8968070337806571	society-of-economic-paleontologists-and-mineralogists
+Society of Ethnobiology	1	0	245	245	245	0.0	society-of-ethnobiology
+Society of Exploration Geophysicists	2	13794	0	19335	19335	0.7134212567882079	society-of-exploration-geophysicists
+Society of Fermentation Technology	1	420	0	0	420	1.0	society-of-fermentation-technology
+Society of Fiber Science and Technology/Sen'i Gakkai	1	0	0	10514	10514	0.0	society-of-fiber-science-and-technology-seni-gakkai
+Society of Field Crops Science	1	0	0	121	121	0.0	society-of-field-crops-science
+Society of Glass Technology	2	74	0	124	124	0.5967741935483871	society-of-glass-technology
+Society of Hospital Pharmacists of Australia	1	527	0	0	534	0.9868913857677902	society-of-hospital-pharmacists-of-australia
+Society of Hungarian Urological Surgeons	1	0	0	0	5	0.0	society-of-hungarian-urological-surgeons
+Society of Industrial and Applied Mathematics	1	723	0	732	732	0.9877049180327869	society-of-industrial-and-applied-mathematics
+Society of Laparoendoscopic Surgeons	1	21	828	828	828	0.025362318840579712	society-of-laparoendoscopic-surgeons
+Society of Materials Engineering for Resources for Japan	1	0	0	0	355	0.0	society-of-materials-engineering-for-resources-for-japan
+Society of Materials Science Japan	1	1	0	11039	11039	9.058791557206268e-5	society-of-materials-science-japan
+Society of Mechanical Engineers	1	5621	0	0	5622	0.9998221273568125	society-of-mechanical-engineers
+Society of Medical Biochemists of Serbia	1	376	428	428	428	0.8785046728971962	society-of-medical-biochemists-of-serbia
+Society of Medical Investigations	1	71	0	208	208	0.34134615384615385	society-of-medical-investigations
+Society of Mining	2	0	0	66	66	0.0	society-of-mining
+Society of Motion and Television Engineers	1	322	0	2680	2680	0.12014925373134329	society-of-motion-and-television-engineers
+Society of Motion Picture and Television Engineers	1	226	0	0	7961	0.028388393417912324	society-of-motion-picture-and-television-engineers
+Society of Naval Architects and Marine Engineers	2	146	0	301	301	0.4850498338870432	society-of-naval-architects-and-marine-engineers
+Society of Nippon Dental University	1	35	0	0	35	1.0	society-of-nippon-dental-university
+Society of Nuclear Medicine	1	468	0	478	478	0.9790794979079498	society-of-nuclear-medicine
+Society of Petroleum Engineers	14	18417	0	4362	18994	0.9696219858902811	society-of-petroleum-engineers
+Society of Photo-Optical Instrumentation Engineers	2	2366	0	2451	2451	0.9653202774377805	society-of-photo-optical-instrumentation-engineers
+Society Of Physical Therapy Science	1	3302	0	3545	3545	0.9314527503526093	society-of-physical-therapy-science
+Society of Protozoologists	1	4317	0	0	4317	1.0	society-of-protozoologists
+Society of Rheology	2	2925	0	4311	4311	0.6784968684759917	society-of-rheology
+Society of Synthetic Organic Chemistry	1	1	0	8000	8000	1.25e-4	society-of-synthetic-organic-chemistry
+Society of Terrestrial Magnetism and Electricity of Japan	1	0	0	0	2663	0.0	society-of-terrestrial-magnetism-and-electricity-of-japan
+Society of Toxicology	1	218	251	251	251	0.8685258964143426	society-of-toxicology
+Society of Tribologists and Lubrication Engineers	1	1324	0	0	1325	0.999245283018868	society-of-tribologists-and-lubrication-engineers
+Sociological Demography Press	1	13	0	122	122	0.10655737704918032	sociological-demography-press
+Sociological Research Online	1	0	0	1171	1171	0.0	sociological-research-online
+SoftwareFirst Ltd	1	0	0	0	112	0.0	softwarefirst-ltd
+Soil and Water Conservation Society	1	606	0	613	613	0.9885807504078303	soil-and-water-conservation-society
+Soil Science Society of America	2	10858	0	17140	17140	0.6334889148191365	soil-science-society-of-america
+Sookmyung Women's University	1	0	0	176	176	0.0	sookmyung-womens-university
+Soonchunhyang University	1	6	538	538	538	0.011152416356877323	soonchunhyang-university
+Sophia University	1	3309	0	3826	3826	0.8648719289074752	sophia-university
+South African Archaeological Society	1	2024	0	2024	2024	1.0	south-african-archaeological-society
+South African Assn. For The Advancement Of Science	1	451	905	905	905	0.4983425414364641	south-african-assn-for-the-advancement-of-science
+South African Bureau for Scientific Publications	5	1747	207	1602	2675	0.6530841121495327	south-african-bureau-for-scientific-publications
+South African Institute of Computer Scientists and Information Technologists	1	0	0	98	98	0.0	south-african-institute-of-computer-scientists-and-information-technologists
+South African Institute of Industrial Engineers	1	0	638	638	638	0.0	south-african-institute-of-industrial-engineers
+South African Institute of Mining and Metallurgy	1	0	0	0	54	0.0	south-african-institute-of-mining-and-metallurgy
+South African Institution of Civil Engineering/Suid-Afrikaanse Instituut van Siviele Ingenieurswese	1	0	0	22	22	0.0	south-african-institution-of-civil-engineering-suid-afrikaanse-instituut-van-siviele-ingenieurswese
+South African Medical Association	3	54	2924	2924	2924	0.018467852257181942	south-african-medical-association
+South African Speech And Hearing Association	1	0	0	112	112	0.0	south-african-speech-and-hearing-association
+South Australian Ornithological Association	1	0	0	1	1	0.0	south-australian-ornithological-association
+South Carolina Entomological Society Inc	1	126	0	127	127	0.9921259842519685	south-carolina-entomological-society-inc
+South China University of Technology	1	768	0	0	768	1.0	south-china-university-of-technology
+South Ural State University	1	0	0	149	149	0.0	south-ural-state-university
+Southeast Asian Regional Centre for Tropical Biology (SEAMEO BIOTROP)	1	0	52	52	52	0.0	southeast-asian-regional-centre-for-tropical-biology-seameo-biotrop
+Southern African Institute of Forestry	3	2159	0	0	2164	0.9976894639556377	southern-african-institute-of-forestry
+Southern African Missiological Society	1	0	23	23	23	0.0	southern-african-missiological-society
+Southern African Wildlife Management Association	1	45	0	47	47	0.9574468085106383	southern-african-wildlife-management-association
+Southern Agricultural Economics Association	1	31	0	0	1296	0.023919753086419752	southern-agricultural-economics-association
+Southern Appalachian Botanical Society	1	568	0	593	593	0.9578414839797639	southern-appalachian-botanical-society
+Southern Cross Journals	1	0	197	197	197	0.0	southern-cross-journals
+Southern Cross Publishing	1	0	0	37	37	0.0	southern-cross-publishing
+Southern Historical Association	1	12535	0	12535	12535	1.0	southern-historical-association
+Southwestern American Indian Society	1	2422	0	0	3052	0.7935779816513762	southwestern-american-indian-society
+Southwestern Association of Naturalists	1	4658	0	4681	4681	0.9950865199743645	southwestern-association-of-naturalists
+Southwestern Entomological Society	1	702	0	728	728	0.9642857142857143	southwestern-entomological-society
+SPA S.L	1	0	286	286	286	0.0	spa-s-l
+Space Research Institute of the Russian Academy of Sciences	1	0	80	80	80	0.0	space-research-institute-of-the-russian-academy-of-sciences
+Spandidos Publications	4	12200	0	16681	17540	0.6955530216647663	spandidos-publications
+Spanish Association of Economic History	1	636	0	641	641	0.9921996879875195	spanish-association-of-economic-history
+Spatial Planning and Sustainable Development	1	0	0	107	107	0.0	spatial-planning-and-sustainable-development
+Special Interest Group on Computer Graphics, Association for Computing Machinery	3	6911	0	518	11952	0.5782295850066934	special-interest-group-on-computer-graphics-association-for-computing-machinery
+Spejalisci Dermatolodzy	1	119	238	238	238	0.5	spejalisci-dermatolodzy
+SPIE	8	26481	0	26923	26923	0.9835828102366007	spie
+Spitalul Clinic Fundeni Bucuresti	1	9	0	0	17	0.5294117647058824	spitalul-clinic-fundeni-bucuresti
+Sports Physical Therapy Section	1	3546	0	3777	3777	0.9388403494837172	sports-physical-therapy-section
+Springer International Publishing	1	741	823	823	823	0.9003645200486027	springer-international-publishing
+Springer Nature	2803	6147387	480720	6214574	6856822	0.8965358879084218	springer-nature
+Springer-Verlag Italia s.r.l.	1	2280	0	2336	2336	0.976027397260274	springer-verlag-italia-s-r-l
+Sreecheta Mukherjee	1	0	84	84	84	0.0	sreecheta-mukherjee
+Sri Lanka College of Paediatricians	1	0	0	865	865	0.0	sri-lanka-college-of-paediatricians
+Sri Lanka Medical Association	1	0	0	1129	1129	0.0	sri-lanka-medical-association
+Srpsko Lekarsko Drustvo/Serbian Medical Association	1	0	0	156	156	0.0	srpsko-lekarsko-drustvo-serbian-medical-association
+St. Petersburg Institute for Informatics and Automation of the Russian academy of sciences	1	0	0	837	837	0.0	st-petersburg-institute-for-informatics-and-automation-of-the-russian-academy-of-sciences
+Stanford Law Review	1	3100	0	3100	3100	1.0	stanford-law-review
+Stash Press	1	492	0	0	492	1.0	stash-press
+State Educational Institution of Higher Professional Training, Sochi State University	1	0	34	34	34	0.0	state-educational-institution-of-higher-professional-training-sochi-state-university
+State Islamic University of Sunan Ampel Surabaya	1	0	163	163	163	0.0	state-islamic-university-of-sunan-ampel-surabaya
+State University of Londrina ECSC - Department of Communication	1	0	275	275	275	0.0	state-university-of-londrina-ecsc-department-of-communication
+State University of New York, Health Science Center at Brooklyn	1	0	0	78	78	0.0	state-university-of-new-york-health-science-center-at-brooklyn
+Statistical Society of Australia	1	1348	0	0	1348	1.0	statistical-society-of-australia
+Statistics Sweden	1	40	215	215	215	0.18604651162790697	statistics-sweden
+Stavropol State Medical University	1	1	0	567	567	0.001763668430335097	stavropol-state-medical-university
+Steinviks Bokforlag	1	608	0	0	608	1.0	steinviks-bokforlag
+Stewart Postharvest Solutions	1	35	0	313	313	0.11182108626198083	stewart-postharvest-solutions
+Stichting Krisis	1	0	0	110	110	0.0	stichting-krisis
+Stichting voor Nederlandse Kunsthistorische Publicaties	1	469	0	469	469	1.0	stichting-voor-nederlandse-kunsthistorische-publicaties
+Stolichnaya Izdatelskaya Kompaniya	1	0	0	824	824	0.0	stolichnaya-izdatelskaya-kompaniya
+Strategic Medical Publishing	1	469	1259	0	1259	0.3725178713264496	strategic-medical-publishing
+Studijski centar socijalnog rada	1	90	995	995	995	0.09045226130653267	studijski-centar-socijalnog-rada
+Stuttgart Fischer	1	56	0	0	56	1.0	stuttgart-fischer
+Suid-Afrikaanse Akademie vir Wetenskap en Kuns/South African Academy of Science and Arts	1	9	0	55	55	0.16363636363636364	suid-afrikaanse-akademie-vir-wetenskap-en-kuns-south-african-academy-of-science-and-arts
+Sultan Qaboos University	1	0	423	423	423	0.0	sultan-qaboos-university
+Sumy State University	1	0	281	281	281	0.0	sumy-state-university
+Sun Media Corporation	1	0	0	16	16	0.0	sun-media-corporation
+Suomalainen Tiedeakatemia/Academia Scientiarum Fennica	2	227	385	388	388	0.5850515463917526	suomalainen-tiedeakatemia-academia-scientiarum-fennica
+Suomen Metsatieteellinen Seura/Finnish Society of Forest Science	1	0	2141	2141	2141	0.0	suomen-metsatieteellinen-seura-finnish-society-of-forest-science
+Superior De Boeck	1	15	0	1244	1244	0.012057877813504822	superior-de-boeck
+Supporting Academic Initiatives Foundation	1	0	125	125	125	0.0	supporting-academic-initiatives-foundation
+Surey Beatty & Sons	1	222	0	1126	1126	0.19715808170515098	surey-beatty-sons
+Surface Financing Society of Japan/Hyomen Gijutus Kyokai	1	23	0	0	4828	0.004763877381938691	surface-financing-society-of-japan-hyomen-gijutus-kyokai
+Surface Science Society of Japan	1	3	1174	1174	1174	0.002555366269165247	surface-science-society-of-japan
+Surgical Sciences Research Society	1	0	0	0	268	0.0	surgical-sciences-research-society
+Surgisphere Corporation	1	0	0	0	13	0.0	surgisphere-corporation
+Sveuciliste Josipa Jurja Strossmayera u Osijeki	1	58	0	486	486	0.11934156378600823	sveuciliste-josipa-jurja-strossmayera-u-osijeki
+Sveuciliste u Zagrebu	2	0	498	498	498	0.0	sveuciliste-u-zagrebu
+Sveza Geodetov Slovenije	1	15	205	205	205	0.07317073170731707	sveza-geodetov-slovenije
+Swedish Association for Behaviour Therapy	1	1020	0	0	1026	0.9941520467836257	swedish-association-for-behaviour-therapy
+Swedish Science Press	1	7623	0	0	7636	0.9982975379779989	swedish-science-press
+Sweet & Maxwell Ltd	1	0	0	35	35	0.0	sweet-maxwell-ltd
+Swets & Zeitlinger	9	2722	0	1524	4909	0.5544917498472194	swets-zeitlinger
+Swiss Forestry Society	1	7	0	966	966	0.007246376811594203	swiss-forestry-society
+Sykepleiernes Samarbeid i Norden	1	513	0	0	514	0.9980544747081712	sykepleiernes-samarbeid-i-norden
+Symposium Journals	4	2175	0	2236	2236	0.9727191413237924	symposium-journals
+Syndicat des Pharmaciens Gerants	1	439	0	0	439	1.0	syndicat-des-pharmaciens-gerants
+Systematic and Applied Acarology Society	1	368	0	924	924	0.39826839826839827	systematic-and-applied-acarology-society
+Szegedi Tudomanyegyetern/University of Szeged	2	0	980	1107	1107	0.0	szegedi-tudomanyegyetern-university-of-szeged
+Szent Istvan University	1	0	693	693	693	0.0	szent-istvan-university
+T.T. Ng Chinese Language Research Centre	1	2	12	12	12	0.16666666666666666	t-t-ng-chinese-language-research-centre
+Tabriz University of Medical Sciences	2	25	149	149	149	0.16778523489932887	tabriz-university-of-medical-sciences
+Tabriz University of Medical Sciences Faculty of Dentistry	1	0	0	0	92	0.0	tabriz-university-of-medical-sciences-faculty-of-dentistry
+Tabriz University of Medical Sciences, Faculty of Pharmacy	1	0	153	153	153	0.0	tabriz-university-of-medical-sciences-faculty-of-pharmacy
+Taehan Kamyom Hakhoe, Taehan Hwahak Yopop Hakhoe	1	4	0	472	472	0.00847457627118644	taehan-kamyom-hakhoe-taehan-hwahak-yopop-hakhoe
+Taehan Kanho Hakhoe	1	0	0	0	428	0.0	taehan-kanho-hakhoe
+Taehan Suhakhoe	2	13	75	1682	1682	0.0077288941736028535	taehan-suhakhoe
+Taehan Uijinkyun Hakhoe	1	0	113	113	113	0.0	taehan-uijinkyun-hakhoe
+Taipei Medical University	1	350	0	0	350	1.0	taipei-medical-university
+Taiwan Institute of Chemical Engineers	1	2186	0	2212	2212	0.9882459312839059	taiwan-institute-of-chemical-engineers
+Taiwan Nurses Association	1	622	0	705	705	0.8822695035460993	taiwan-nurses-association
+Talleres Editoriales Cometa, S.A	1	0	167	167	167	0.0	talleres-editoriales-cometa-s-a
+Tamkang University	1	1	258	258	258	0.003875968992248062	tamkang-university
+Tartu University Press	4	31	495	495	495	0.06262626262626263	tartu-university-press
+Tata Energy Research Institute	1	0	0	0	6	0.0	tata-energy-research-institute
+Taylor & Francis	2710	3000211	78101	2924219	3241697	0.925506301174971	taylor-francis
+Taylor and Francis Ltd.	1	0	0	1036	1036	0.0	taylor-and-francis-ltd
+Taylor's University	1	0	0	8	8	0.0	taylors-university
+Teachers College Record	1	441	0	699	699	0.630901287553648	teachers-college-record
+Teaduste Akadeemia Kirjastus/Estonian Academy Publishers	2	0	246	246	246	0.0	teaduste-akadeemia-kirjastus-estonian-academy-publishers
+Teagasc	1	10	34	34	34	0.29411764705882354	teagasc
+Technical Association of Photopolymers	1	3224	0	3290	3290	0.9799392097264438	technical-association-of-photopolymers
+Technical University Liberec	1	2	0	178	178	0.011235955056179775	technical-university-liberec
+Technical University of Kosice	1	0	112	112	112	0.0	technical-university-of-kosice
+Technical University Press	1	191	0	971	971	0.19670442842430483	technical-university-press
+Technicka Univerzita Kosice	1	0	0	184	184	0.0	technicka-univerzita-kosice
+Technische Universität Graz	1	0	8	8	8	0.0	technische-universitat-graz
+Technischen Universitat Braunschweig	1	1	657	657	657	0.0015220700152207	technischen-universitat-braunschweig
+Techno Press	7	165	0	4283	4283	0.03852439878589774	techno-press
+Technology Education Program, Virginia Polytechnic Institute and State University	1	0	321	321	321	0.0	technology-education-program-virginia-polytechnic-institute-and-state-university
+Technosdar Ltd	1	21	56	56	56	0.375	technosdar-ltd
+Tehran University of Medical Sciences	4	169	288	390	458	0.36899563318777295	tehran-university-of-medical-sciences
+Telecommunications Association	2	0	0	157	371	0.0	telecommunications-association
+Telos Press	1	2269	0	2438	2438	0.9306808859721083	telos-press
+Tercer Mundo Editores	2	184	106	294	294	0.6258503401360545	tercer-mundo-editores
+Termedia Publishing House Ltd.	17	860	4997	6570	6570	0.1308980213089802	termedia-publishing-house-ltd
+Texas Heart Institute	1	230	532	532	532	0.4323308270676692	texas-heart-institute
+Texas Tech University	3	74	0	474	662	0.11178247734138973	texas-tech-university
+Textile Bioengineering and Informatics Society, The Hong Kong Polytechnic University	1	1	0	356	356	0.0028089887640449437	textile-bioengineering-and-informatics-society-the-hong-kong-polytechnic-university
+Textile Machinery Society of Japan	3	0	0	320	3949	0.0	textile-machinery-society-of-japan
+Thailand's National Science and Technology Development Agency	1	21	1606	1606	1606	0.013075965130759652	thailands-national-science-and-technology-development-agency
+Thanet Press	1	579	0	0	579	1.0	thanet-press
+The Advertising Research Foundation	1	38	0	887	887	0.04284103720405862	the-advertising-research-foundation
+The Allergy and Immunology Society of Thailand	1	0	0	176	176	0.0	the-allergy-and-immunology-society-of-thailand
+The American Academy of Sleep Medicine	1	20	0	1203	1203	0.01662510390689942	the-american-academy-of-sleep-medicine
+The Asian Association of Teachers of English as a Foreign Language	1	0	0	79	79	0.0	the-asian-association-of-teachers-of-english-as-a-foreign-language
+The Association for the Study of Literature and Environment (ASLE)	1	2493	0	2558	2558	0.9745895230648944	the-association-for-the-study-of-literature-and-environment-asle
+The Australasian Medical Journal Pty. Ltd	1	421	738	738	738	0.5704607046070461	the-australasian-medical-journal-pty-ltd
+The Austrian Academy of Sciences Press	1	0	0	239	239	0.0	the-austrian-academy-of-sciences-press
+The British Micropalaeontological Society	1	579	0	735	735	0.7877551020408163	the-british-micropalaeontological-society
+The British Psychological Society	2	3809	0	0	3811	0.9994752033586985	the-british-psychological-society
+The Clay Minerals Society	1	809	0	4201	4201	0.19257319685789098	the-clay-minerals-society
+The Coleopterists Society	1	1493	0	1525	1525	0.9790163934426229	the-coleopterists-society
+The Company of Biologists Ltd.	4	24419	1198	25477	25477	0.9584723476076461	the-company-of-biologists-ltd
+The Ecological Society of Korea	1	0	0	0	44	0.0	the-ecological-society-of-korea
+The Egyptian Society for Joint Diseases and Arthritis	1	272	281	281	281	0.9679715302491103	the-egyptian-society-for-joint-diseases-and-arthritis
+The Egyptian Society of Radiology and Nuclear Medicine	1	860	893	893	893	0.9630459126539753	the-egyptian-society-of-radiology-and-nuclear-medicine
+The Electrochemical Society	2	750	0	750	750	1.0	the-electrochemical-society
+The Endocrine Society	3	6943	0	10507	10586	0.6558662384281126	the-endocrine-society
+The Fairmont Press Inc.	2	296	0	0	381	0.7769028871391076	the-fairmont-press-inc
+The Finnish Society for Science and Technology Studies	1	0	5	5	5	0.0	the-finnish-society-for-science-and-technology-studies
+The General Jonas Zemaitis Military Academy of Lithuania	1	0	0	135	135	0.0	the-general-jonas-zemaitis-military-academy-of-lithuania
+The Heart Surgery Forum	1	6	0	1244	1244	0.00482315112540193	the-heart-surgery-forum
+The Information Resources Management Association (IRMA)	3	2	0	529	529	0.003780718336483932	the-information-resources-management-association-irma
+The Institute of Electrical Engineers of Japan	7	111	0	27405	27405	0.0040503557744937056	the-institute-of-electrical-engineers-of-japan
+The Institute of Electronics Engineers of Korea	1	10	0	644	644	0.015527950310559006	the-institute-of-electronics-engineers-of-korea
+The Institution of Engineering and Technology	2	269	0	318	318	0.8459119496855346	the-institution-of-engineering-and-technology
+The International Society for the Study of Religion, Nature & Culture	1	229	0	625	625	0.3664	the-international-society-for-the-study-of-religion-nature-culture
+The Italian Society of Silviculture and Forest Ecology (SISEF)	1	220	580	580	580	0.3793103448275862	the-italian-society-of-silviculture-and-forest-ecology-sisef
+The Japan Institute of Electronics Packaging	1	0	0	2365	2365	0.0	the-japan-institute-of-electronics-packaging
+The Japan Section of the Regional Science Association International	1	0	0	1588	1588	0.0	the-japan-section-of-the-regional-science-association-international
+The Japan Society of Plasma Science and Nuclear Fusion Research (JSPF)	1	4	0	1529	1529	0.002616088947024199	the-japan-society-of-plasma-science-and-nuclear-fusion-research-jspf
+The Japanese Society of Neuroendovascular Therapy	1	0	0	491	491	0.0	the-japanese-society-of-neuroendovascular-therapy
+The Japanese Stomatological Society	1	194	0	196	196	0.9897959183673469	the-japanese-stomatological-society
+The Korean Academy of prosthodontics	1	11	440	440	440	0.025	the-korean-academy-of-prosthodontics
+The Korean Academy of Speech-Language Pathology and Audiology (KASA)	1	0	0	209	209	0.0	the-korean-academy-of-speech-language-pathology-and-audiology-kasa
+The Korean Electrochemical Society	1	3	178	178	178	0.016853932584269662	the-korean-electrochemical-society
+The Korean Institute of Chemical Engineers	1	0	0	808	808	0.0	the-korean-institute-of-chemical-engineers
+The Korean Institute of Electrical and Electronic Material Engineers	1	8	890	890	890	0.008988764044943821	the-korean-institute-of-electrical-and-electronic-material-engineers
+The Korean Institute of Electromagnetic Engineering and Science	1	0	0	395	395	0.0	the-korean-institute-of-electromagnetic-engineering-and-science
+The Korean Magnestics Society	1	3	0	809	809	0.003708281829419036	the-korean-magnestics-society
+The Korean Nutrition Society	1	1	0	213	213	0.004694835680751174	the-korean-nutrition-society
+The Korean Pain Society	1	4	0	377	377	0.010610079575596816	the-korean-pain-society
+The Korean Society for Aeronautical & Space Sciences	1	0	0	521	521	0.0	the-korean-society-for-aeronautical-space-sciences
+The Korean Society for Applied Biological Chemistry	2	879	0	460	1381	0.6364952932657495	the-korean-society-for-applied-biological-chemistry
+The Korean Society of Community Nutrition	1	17	763	763	763	0.022280471821756225	the-korean-society-of-community-nutrition
+The Korean Society of Genetics	1	772	0	792	792	0.9747474747474747	the-korean-society-of-genetics
+The Korean Society of Phycology	1	7	526	526	526	0.013307984790874524	the-korean-society-of-phycology
+The Korean Society of Precision Engineering	1	318	0	318	318	1.0	the-korean-society-of-precision-engineering
+The Korean Space Science Society	1	1	651	651	651	0.0015360983102918587	the-korean-space-science-society
+The Lietuvos Istorijos Institutas	1	0	0	110	110	0.0	the-lietuvos-istorijos-institutas
+The Metallurgical Industry Press	1	2509	0	2511	2511	0.9992035045798486	the-metallurgical-industry-press
+The National Bureau of Asian Research	1	75	0	485	485	0.15463917525773196	the-national-bureau-of-asian-research
+The National Center for Geographic Information and Analysis (NCGIA)	1	1	80	80	80	0.0125	the-national-center-for-geographic-information-and-analysis-ncgia
+The Nordic Society of Aesthetics	1	0	0	388	388	0.0	the-nordic-society-of-aesthetics
+The Old Corner Bookstore	1	1985	0	0	2291	0.866433871671759	the-old-corner-bookstore
+The Online Learning Consortium	1	0	0	317	317	0.0	the-online-learning-consortium
+The Optical Society	2	1986	2326	2419	2419	0.8210004133939645	the-optical-society
+The Orton Society	1	537	0	0	537	1.0	the-orton-society
+The Oto-Rhingo-Laryngological Society of Japan	1	12828	0	13055	13055	0.9826120260436614	the-oto-rhingo-laryngological-society-of-japan
+The Paleontological Society of Japan	1	393	0	394	394	0.9974619289340102	the-paleontological-society-of-japan
+The Permanente Press	1	3	953	953	953	0.0031479538300104933	the-permanente-press
+The Policy Press	5	2266	0	2614	2614	0.8668706962509564	the-policy-press
+The Publishing House Dynasty	1	0	0	40	40	0.0	the-publishing-house-dynasty
+The Research Council of Norway	1	8	566	566	566	0.014134275618374558	the-research-council-of-norway
+The Resilience Alliance	3	448	2032	2032	2360	0.18983050847457628	the-resilience-alliance
+The Resources Processing Society of Japan	1	0	0	0	209	0.0	the-resources-processing-society-of-japan
+The Royal Society	11	59348	1333	64214	65789	0.9020960950918847	the-royal-society
+The School of Electrical Engineering and Informatics, Institut Teknologi Bandung	1	0	340	340	340	0.0	the-school-of-electrical-engineering-and-informatics-institut-teknologi-bandung
+The Serbian Society for Computational Mechanics (SSCM)	1	0	0	36	36	0.0	the-serbian-society-for-computational-mechanics-sscm
+The Silesian University of Technology, Faculty of Transport	1	0	56	56	56	0.0	the-silesian-university-of-technology-faculty-of-transport
+The Society for Ultrasound in Anaesthesia	1	0	0	0	20	0.0	the-society-for-ultrasound-in-anaesthesia
+The Society of Bioscience and Bioengineering Japan/Seibutsu Kogakkai	1	2736	0	0	2736	1.0	the-society-of-bioscience-and-bioengineering-japan-seibutsu-kogakkai
+The Society of Polymer Science	1	7570	0	8539	8539	0.886520669867666	the-society-of-polymer-science
+The Spanish Quaternary Research Association (AEQUA) and the Spanish Society of Geomorphology (SEG)	1	0	0	25	25	0.0	the-spanish-quaternary-research-association-aequa-and-the-spanish-society-of-geomorphology-seg
+The Technical University of Lodz	1	33	49	49	49	0.673469387755102	the-technical-university-of-lodz
+The University of Arkansas Press	1	0	0	818	818	0.0	the-university-of-arkansas-press
+The University of Jordan	1	0	0	109	109	0.0	the-university-of-jordan
+Thieme	101	311523	1668	390337	435459	0.7153899678270514	thieme
+thinkBiotech	1	158	0	1058	1058	0.14933837429111532	thinkbiotech
+Thomas Land Publishers Inc.	2	603	0	2141	2141	0.28164409154600656	thomas-land-publishers-inc
+Thomas Telford Ltd.	10	5455	0	6707	7093	0.7690680953052305	thomas-telford-ltd
+Thracian University, Faculty of Veterinary Medicine	1	0	70	70	70	0.0	thracian-university-faculty-of-veterinary-medicine
+Tianjin Daxue/Tianjin University	1	700	0	736	736	0.9510869565217391	tianjin-daxue-tianjin-university
+Tijdschrift Voor Geneeskunde A.S.B.L.	1	0	0	5502	5502	0.0	tijdschrift-voor-geneeskunde-a-s-b-l
+Tilgher-Genova	1	0	0	68	68	0.0	tilgher-genova
+Time Inc.	1	0	0	1	1	0.0	time-inc
+Tissue Culture Association	2	2001	0	0	2001	1.0	tissue-culture-association
+Tissue Viability Society	1	1053	0	1063	1063	0.9905926622765757	tissue-viability-society
+TMMOB Chamber of Textile Engineers	1	0	0	132	132	0.0	tmmob-chamber-of-textile-engineers
+Tohoku University	2	10661	10446	13113	13113	0.813009990086174	tohoku-university
+Tokushima Daigaku Igakubu	1	1	686	686	686	0.0014577259475218659	tokushima-daigaku-igakubu
+Tokyo Ika Shika Daigaku Shigakubu Kaibogaku Kyoshitsu	1	0	0	0	2092	0.0	tokyo-ika-shika-daigaku-shigakubu-kaibogaku-kyoshitsu
+Tokyo Institute of Technology	1	157	0	1379	1379	0.11385061638868746	tokyo-institute-of-technology
+Tokyo Shika Daigaku Gakkai/Tokyo Dental College Society	1	0	0	0	427	0.0	tokyo-shika-daigaku-gakkai-tokyo-dental-college-society
+Tokyo University of Agriculture	1	1487	1509	1509	1509	0.9854208084824387	tokyo-university-of-agriculture
+Tomsk State University	3	0	162	336	336	0.0	tomsk-state-university
+Tong Kwahak Hoe	1	0	0	694	694	0.0	tong-kwahak-hoe
+Torrey Botanical Club	1	6234	0	0	6234	1.0	torrey-botanical-club
+Torrey Botanical Society	1	883	0	891	891	0.9910213243546577	torrey-botanical-society
+Touch Briefings	3	0	0	1173	1173	0.0	touch-briefings
+Touch Digital Media	1	0	0	492	492	0.0	touch-digital-media
+Trakya Universitesi	1	171	0	0	183	0.9344262295081968	trakya-universitesi
+Trans Tech Publications	2	145	0	618	618	0.23462783171521034	trans-tech-publications
+Trans Tech Publications Ltd.	5	139106	0	20430	165863	0.838680115517023	trans-tech-publications-ltd
+Transaction Periodicals Consortium	4	2109	0	1807	2213	0.9530049706281066	transaction-periodicals-consortium
+Transaction Publishers	3	924	0	283	924	1.0	transaction-publishers
+Transport and Telecommunication Institute	1	60	151	151	151	0.3973509933774834	transport-and-telecommunication-institute
+Tree-Ring Society	1	215	0	221	221	0.9728506787330317	tree-ring-society
+Trent University	1	0	0	1986	1986	0.0	trent-university
+Trentham Books	1	250	0	0	252	0.9920634920634921	trentham-books
+Triangle Journals Ltd.	1	7	0	0	7	1.0	triangle-journals-ltd
+Tsinghua University	5	3781	362	3837	3837	0.9854052645295804	tsinghua-university
+Tsvetnaya Metallurgiya	1	0	0	0	253	0.0	tsvetnaya-metallurgiya
+Tuberculosis Association of India	1	245	0	266	266	0.9210526315789473	tuberculosis-association-of-india
+Tufts University	1	1120	0	1150	1150	0.9739130434782609	tufts-university
+Turk Algoloji (Agri) Dernegi	1	1	0	241	241	0.004149377593360996	turk-algoloji-agri-dernegi
+Turk Biyokimya Dernegi	1	300	0	476	476	0.6302521008403361	turk-biyokimya-dernegi
+Turk Kardiyoloji Dernegi	1	3	0	1044	1044	0.0028735632183908046	turk-kardiyoloji-dernegi
+Turk Norpsikiyatri Dernegi	1	245	0	717	717	0.3417015341701534	turk-norpsikiyatri-dernegi
+Turk Onkoloji Dernegi	1	100	0	152	152	0.6578947368421053	turk-onkoloji-dernegi
+Turk Ortopedi ve Travmatoloji Dernegi	1	112	999	999	999	0.11211211211211211	turk-ortopedi-ve-travmatoloji-dernegi
+Turk Patoloji Dernegi	1	227	476	476	476	0.47689075630252103	turk-patoloji-dernegi
+Turkish Academy of Scieces	1	0	0	215	215	0.0	turkish-academy-of-scieces
+Turkish Chamber of Civil Engineers	1	0	0	1	1	0.0	turkish-chamber-of-civil-engineers
+Turkish Education Association	1	0	0	343	343	0.0	turkish-education-association
+Turkish Journal of Neurology	1	35	0	164	164	0.21341463414634146	turkish-journal-of-neurology
+Turkish Neurosurgical Society	1	13	0	1182	1182	0.010998307952622674	turkish-neurosurgical-society
+Turkish Ophthalmological Society	1	272	613	613	613	0.4437194127243067	turkish-ophthalmological-society
+Turkish Pharmacists Association	1	0	0	60	60	0.0	turkish-pharmacists-association
+Turkish Society of Cerebrovascular Diseases	1	0	106	0	106	0.0	turkish-society-of-cerebrovascular-diseases
+Turkish Society of Gastroenterology	1	15	0	1182	1182	0.012690355329949238	turkish-society-of-gastroenterology
+Turkish society of Nephrology	1	1	480	480	480	0.0020833333333333333	turkish-society-of-nephrology
+Turkish Society of Osteoporosis	1	60	0	173	173	0.3468208092485549	turkish-society-of-osteoporosis
+Turkiye Eklem Hastaliklari Tedavi Vakfi	1	0	0	162	162	0.0	turkiye-eklem-hastaliklari-tedavi-vakfi
+Turkiye Klinikleri	4	0	0	357	357	0.0	turkiye-klinikleri
+Turkiye Klinikleri Journal of Medical Sciences	1	0	0	1240	1240	0.0	turkiye-klinikleri-journal-of-medical-sciences
+Turkiye Sinir ve Ruh Sagligi Dernegi	1	2	0	176	176	0.011363636363636364	turkiye-sinir-ve-ruh-sagligi-dernegi
+Turpion - Moscow Ltd.	2	9773	0	0	20664	0.47294812233836625	turpion-moscow-ltd
+Turpion Ltd	3	11356	0	11679	11679	0.9723435225618632	turpion-ltd
+Tusi Mathematical Research Group	1	139	314	314	314	0.4426751592356688	tusi-mathematical-research-group
+Tyumen State University	1	0	0	18	18	0.0	tyumen-state-university
+U.S. Agency for International Development	1	212	274	274	274	0.7737226277372263	u-s-agency-for-international-development
+U.S. Fish & Wildlife Service	1	2	0	331	331	0.006042296072507553	u-s-fish-wildlife-service
+Ubiquity Press Limited	1	1	195	195	195	0.005128205128205128	ubiquity-press-limited
+Udmurt State University	1	0	507	507	507	0.0	udmurt-state-university
+Udruzenje basicnih mediciniskih znanosti FBIH Sarajevo	1	1	147	147	147	0.006802721088435374	udruzenje-basicnih-mediciniskih-znanosti-fbih-sarajevo
+Udruzenje Hirurga Jugoslavije	1	4	0	0	1041	0.0038424591738712775	udruzenje-hirurga-jugoslavije
+Ufa State Academy of Arts	1	0	150	150	150	0.0	ufa-state-academy-of-arts
+UFPR, Departamento de Geologia	1	0	0	193	193	0.0	ufpr-departamento-de-geologia
+UIN Sunan Kalijaga	1	0	195	195	195	0.0	uin-sunan-kalijaga
+Uitgeverij Boom	1	0	0	105	105	0.0	uitgeverij-boom
+Uitgeverij Verloren	1	0	181	181	181	0.0	uitgeverij-verloren
+Ulusal Travma ve Acil Cerrahi Dernegi	1	15	0	725	725	0.020689655172413793	ulusal-travma-ve-acil-cerrahi-dernegi
+UNAM, Instituto de Investigaciones Filologicas	1	44	237	237	237	0.18565400843881857	unam-instituto-de-investigaciones-filologicas
+Undersea and Hyperbaric Medical Society	1	0	0	15	15	0.0	undersea-and-hyperbaric-medical-society
+Undo Seiri Kenkyukai	1	2048	0	2106	2106	0.9724596391263058	undo-seiri-kenkyukai
+Union pour l'etude de la population africaine	1	0	0	313	313	0.0	union-pour-letude-de-la-population-africaine
+Unisinos	1	0	0	240	240	0.0	unisinos
+United Arab Emirates University	1	284	864	864	864	0.3287037037037037	united-arab-emirates-university
+United Kingdom Serials Group	2	20	314	314	1596	0.012531328320802004	united-kingdom-serials-group
+United Kingdom Simulation Society	1	0	0	1	1	0.0	united-kingdom-simulation-society
+United Nations Economic and Social Commission for Asia and the Pacific	1	0	0	63	63	0.0	united-nations-economic-and-social-commission-for-asia-and-the-pacific
+Uniunea Societatilor De Stiinte Medicale	1	0	0	42	42	0.0	uniunea-societatilor-de-stiinte-medicale
+Univ Feder Uberlandia	1	0	0	86	86	0.0	univ-feder-uberlandia
+UNIVALI (Universidade do Vale do Itajai)	1	1	0	348	348	0.0028735632183908046	univali-universidade-do-vale-do-itajai
+Univerisity Department of Psychiatry University Hospital Center Sestre milosrdnice	1	0	0	6	6	0.0	univerisity-department-of-psychiatry-university-hospital-center-sestre-milosrdnice
+Universidad Alberto Hurtado/School of Economics and Bussines	1	0	70	70	70	0.0	universidad-alberto-hurtado-school-of-economics-and-bussines
+Universidad Austral de Chile	6	6	2584	3109	3109	0.0019298809906722419	universidad-austral-de-chile
+Universidad Autonoma Chapingo	2	7	165	707	707	0.009900990099009901	universidad-autonoma-chapingo
+Universidad Autonoma de Baja California	1	69	213	213	213	0.323943661971831	universidad-autonoma-de-baja-california
+Universidad Autonoma de Madrid	3	0	134	189	189	0.0	universidad-autonoma-de-madrid
+Universidad Autonoma del Estado de Mexico, Centro de Investigacion y Estudios Avanzados de la Poblacion	1	0	0	20	20	0.0	universidad-autonoma-del-estado-de-mexico-centro-de-investigacion-y-estudios-avanzados-de-la-poblacion
+Universidad Carlos III de Madrid	1	0	0	24	24	0.0	universidad-carlos-iii-de-madrid
+Universidad Catolica de Colombia	1	0	0	124	124	0.0	universidad-catolica-de-colombia
+Universidad Catolica de San Antonio de Murcia	1	0	238	238	238	0.0	universidad-catolica-de-san-antonio-de-murcia
+Universidad Catolica de Valparaiso	1	0	0	0	340	0.0	universidad-catolica-de-valparaiso
+Universidad Catolica, Facultad de Teologia	1	0	562	562	562	0.0	universidad-catolica-facultad-de-teologia
+Universidad Colegio Mayor de Nuestra Senora del Rosario	1	0	24	24	24	0.0	universidad-colegio-mayor-de-nuestra-senora-del-rosario
+Universidad Complutense De Madrid	23	0	1939	3776	3833	0.0	universidad-complutense-de-madrid
+Universidad Complutense, Departamento de Historia de America II	1	0	0	121	121	0.0	universidad-complutense-departamento-de-historia-de-america-ii
+Universidad de Alicante	3	0	0	607	607	0.0	universidad-de-alicante
+Universidad De Antioquia	6	0	322	404	404	0.0	universidad-de-antioquia
+Universidad de Caldas	1	0	0	20	20	0.0	universidad-de-caldas
+Universidad de Castilla la Mancha	2	0	158	158	158	0.0	universidad-de-castilla-la-mancha
+Universidad de Chile	5	2	1108	1108	1334	0.0014992503748125937	universidad-de-chile
+Universidad de Chile, Facultad de Ciencias Sociales	1	0	0	139	139	0.0	universidad-de-chile-facultad-de-ciencias-sociales
+Universidad de Concepcion	6	5	1770	1964	1964	0.0025458248472505093	universidad-de-concepcion
+Universidad de Concepcion, Facultad de Medicina, Departmento de Enfermeria	1	0	377	377	377	0.0	universidad-de-concepcion-facultad-de-medicina-departmento-de-enfermeria
+Universidad de Cordoba	3	0	42	211	211	0.0	universidad-de-cordoba
+Universidad de Costa Rica	1	0	488	488	488	0.0	universidad-de-costa-rica
+Universidad de Jaen	1	0	0	6	6	0.0	universidad-de-jaen
+Universidad de La Rioja	1	0	0	390	390	0.0	universidad-de-la-rioja
+Universidad de La Sabana	2	51	484	484	484	0.10537190082644628	universidad-de-la-sabana
+Universidad de los Andes	5	256	1063	1085	1085	0.2359447004608295	universidad-de-los-andes
+Universidad de Los Lagos	1	0	513	513	513	0.0	universidad-de-los-lagos
+Universidad de Murcia	1	0	62	62	62	0.0	universidad-de-murcia
+Universidad de Murcia Servicio de Publicaciones	1	0	739	739	739	0.0	universidad-de-murcia-servicio-de-publicaciones
+Universidad de Murcia. Departamento de Filosofia y Lgica.	1	0	238	238	238	0.0	universidad-de-murcia-departamento-de-filosofia-y-lgica
+Universidad de Navarra	6	0	183	310	310	0.0	universidad-de-navarra
+Universidad de Oviedo	2	0	4	33	33	0.0	universidad-de-oviedo
+Universidad de Salamanca	4	0	217	238	238	0.0	universidad-de-salamanca
+Universidad de Salamanca, Facultad de EducaciOn	1	0	61	61	61	0.0	universidad-de-salamanca-facultad-de-educacion
+Universidad de San Buenaventura	1	0	128	128	128	0.0	universidad-de-san-buenaventura
+Universidad de Santiago de Chile	1	0	126	126	126	0.0	universidad-de-santiago-de-chile
+Universidad de Santiago de Compostela	2	0	31	51	51	0.0	universidad-de-santiago-de-compostela
+Universidad de Sevilla, Servicio de Publicaciones	2	0	103	125	125	0.0	universidad-de-sevilla-servicio-de-publicaciones
+Universidad de Tarapaca	3	3	1213	1213	1213	0.00247320692497939	universidad-de-tarapaca
+Universidad de Valencia	1	0	225	225	225	0.0	universidad-de-valencia
+Universidad de Valladolid	1	0	11	11	11	0.0	universidad-de-valladolid
+Universidad de Zaragoza	1	4	264	264	264	0.015151515151515152	universidad-de-zaragoza
+Universidad Del Atlantico	1	0	62	62	62	0.0	universidad-del-atlantico
+Universidad del Bio-Bio	1	161	475	475	475	0.3389473684210526	universidad-del-bio-bio
+Universidad del Norte	4	28	457	578	578	0.04844290657439446	universidad-del-norte
+Universidad del Norte, Sede Arica, Depto. de Antropologia	1	2	731	731	731	0.0027359781121751026	universidad-del-norte-sede-arica-depto-de-antropologia
+Universidad del Pais Vasco	2	0	130	182	182	0.0	universidad-del-pais-vasco
+Universidad del Rosario (Colombia)	1	2	121	121	121	0.01652892561983471	universidad-del-rosario-colombia
+Universidad del Rosario, Escuela de Ciencias de la Salud	1	0	139	139	139	0.0	universidad-del-rosario-escuela-de-ciencias-de-la-salud
+Universidad del Zulia	1	0	0	554	554	0.0	universidad-del-zulia
+Universidad Distrital Francisco Jose de Caldas	1	0	0	171	171	0.0	universidad-distrital-francisco-jose-de-caldas
+Universidad EAFIT	1	0	38	38	38	0.0	universidad-eafit
+Universidad Externado de Colombia	2	0	97	97	97	0.0	universidad-externado-de-colombia
+Universidad Industrial de Santander	1	0	34	34	34	0.0	universidad-industrial-de-santander
+"Universidad Nacional ""Campus Omar Dengo"""	1	0	0	0	11	0.0	universidad-nacional-campus-omar-dengo
+Universidad Nacional Autonoma de Mexico	16	5456	6437	8541	8541	0.6388010771572415	universidad-nacional-autonoma-de-mexico
+Universidad Nacional Autónoma de México, Universidad Autónoma de México, Universidad Autónoma de Tlaxcala, Universidad de Veracruzana	1	0	0	56	56	0.0	universidad-nacional-autonoma-de-mexico-universidad-autonoma-de-mexico-universidad-autonoma-de-tlaxcala-universidad-de-veracruzana
+Universidad Nacional De Colombia	19	15	2284	3411	3411	0.0043975373790677225	universidad-nacional-de-colombia
+Universidad Nacional de Educacion a Distancia	3	0	749	862	862	0.0	universidad-nacional-de-educacion-a-distancia
+Universidad Nacional de Educacion a Distancia, UNED	3	0	550	1394	1394	0.0	universidad-nacional-de-educacion-a-distancia-uned
+Universidad Nacional de La Pampa	1	0	100	100	100	0.0	universidad-nacional-de-la-pampa
+Universidad Nacional de Lanus	1	0	331	331	331	0.0	universidad-nacional-de-lanus
+Universidad Nacional, Escuela de Historia	1	0	0	0	21	0.0	universidad-nacional-escuela-de-historia
+Universidad Panamericana	1	0	0	636	636	0.0	universidad-panamericana
+Universidad Pedagogica y Tecnologica de Colombia	1	0	95	95	95	0.0	universidad-pedagogica-y-tecnologica-de-colombia
+Universidad Politecnica de Valencia	3	0	157	838	838	0.0	universidad-politecnica-de-valencia
+Universidade Catolica Portuguesa	1	0	0	100	100	0.0	universidade-catolica-portuguesa
+Universidade da Beira Interior	1	0	0	42	42	0.0	universidade-da-beira-interior
+Universidade da Coruna	1	0	16	16	16	0.0	universidade-da-coruna
+Universidade de Brasilia	2	0	234	374	374	0.0	universidade-de-brasilia
+Universidade de Coimbra	2	0	0	0	124	0.0	universidade-de-coimbra
+Universidade de Coimbra - Faculdade de Letras	1	0	0	222	222	0.0	universidade-de-coimbra-faculdade-de-letras
+Universidade de Coimbra, Instituto de Historia Economica e social	1	0	0	172	172	0.0	universidade-de-coimbra-instituto-de-historia-economica-e-social
+Universidade de Lisboa	1	0	0	856	856	0.0	universidade-de-lisboa
+Universidade de Minas Gerais	1	0	0	540	540	0.0	universidade-de-minas-gerais
+Universidade de Sao Paulo	24	165	9729	11415	14485	0.011391094235415948	universidade-de-sao-paulo
+Universidade de Sao Paulo. Faculdade de Medicina Veterinari	1	2	1604	1604	1604	0.0012468827930174563	universidade-de-sao-paulo-faculdade-de-medicina-veterinari
+Universidade Do Estado de Santa Catarina	1	0	238	238	238	0.0	universidade-do-estado-de-santa-catarina
+Universidade do Estado do Rio de Janeiro	1	0	0	248	248	0.0	universidade-do-estado-do-rio-de-janeiro
+Universidade do Vale do Rio dos Sinos	4	2	52	538	538	0.0037174721189591076	universidade-do-vale-do-rio-dos-sinos
+Universidade do Vale do Rio dos Sinos (UNISINOS)	2	0	0	179	179	0.0	universidade-do-vale-do-rio-dos-sinos-unisinos
+Universidade Estadual de Campinas	2	0	331	331	331	0.0	universidade-estadual-de-campinas
+Universidade Estadual de Campinas, Instituto de Filosofia e Ciencias Humanas, Pagu, Centro de Estudos de Genero	1	1	446	446	446	0.002242152466367713	universidade-estadual-de-campinas-instituto-de-filosofia-e-ciencias-humanas-pagu-centro-de-estudos-de-genero
+Universidade Estadual de Londrina	1	23	3225	3225	3225	0.007131782945736434	universidade-estadual-de-londrina
+Universidade Estadual de Maringa	10	498	4482	6250	6703	0.0742950917499627	universidade-estadual-de-maringa
+Universidade Estadual Paulista - UNESP	5	5	2619	2795	2795	0.0017889087656529517	universidade-estadual-paulista-unesp
+Universidade Federal da Bahia	1	0	431	431	431	0.0	universidade-federal-da-bahia
+Universidade Federal De Goias (UFG)	4	8	1441	1458	1458	0.0054869684499314125	universidade-federal-de-goias-ufg
+Universidade Federal de Lavras	1	4	2005	2005	2005	0.00199501246882793	universidade-federal-de-lavras
+Universidade Federal de Mato Grosso do Sul, Departamento de Quimica	1	9	0	98	98	0.09183673469387756	universidade-federal-de-mato-grosso-do-sul-departamento-de-quimica
+Universidade Federal de Minas Gerais	4	8	3487	3960	3960	0.00202020202020202	universidade-federal-de-minas-gerais
+Universidade Federal de Santa Catarina	5	6	2371	2371	2371	0.0025305778152678194	universidade-federal-de-santa-catarina
+Universidade Federal de Santa Maria	1	0	233	233	233	0.0	universidade-federal-de-santa-maria
+Universidade Federal de Sao Carlos	3	177	3116	3116	3116	0.05680359435173299	universidade-federal-de-sao-carlos
+Universidade Federal de Sao Paulo	1	2	0	337	337	0.005934718100890208	universidade-federal-de-sao-paulo
+Universidade Federal De Vicosa	1	0	821	821	821	0.0	universidade-federal-de-vicosa
+Universidade Federal do Ceara	1	3	787	787	787	0.0038119440914866584	universidade-federal-do-ceara
+Universidade Federal do Estado do Rio de Janeiro, Programa de Pos-Graduacao em Historia	1	0	230	230	230	0.0	universidade-federal-do-estado-do-rio-de-janeiro-programa-de-pos-graduacao-em-historia
+Universidade Federal do Parana	6	1	2802	4082	4082	2.449779519843214e-4	universidade-federal-do-parana
+Universidade Federal Do Rio De Janeiro	6	4	1440	1825	2034	0.0019665683382497543	universidade-federal-do-rio-de-janeiro
+Universidade Federal do Rio de Janeiro, Coordenacao dos Programas de Pos-Graduacao em Engenharia	1	2	692	692	692	0.002890173410404624	universidade-federal-do-rio-de-janeiro-coordenacao-dos-programas-de-pos-graduacao-em-engenharia
+Universidade Federal do Rio Grande do Norte	1	2	702	702	702	0.002849002849002849	universidade-federal-do-rio-grande-do-norte
+Universidade Federal do Rio Grande do Sul	3	0	1340	1340	1340	0.0	universidade-federal-do-rio-grande-do-sul
+Universidade Federal Fluminense	1	0	376	376	376	0.0	universidade-federal-fluminense
+Universidade Federal Rural de Pernambuco	2	11	832	832	832	0.013221153846153846	universidade-federal-rural-de-pernambuco
+Universidade Federal Rural do Rio de Janeiro, Instituto de Florestas	1	4	389	389	389	0.010282776349614395	universidade-federal-rural-do-rio-de-janeiro-instituto-de-florestas
+Universidade Federal Rural do Semi-Arido	2	0	328	328	328	0.0	universidade-federal-rural-do-semi-arido
+Universidade Metodista de Piracicaba	1	0	11	11	11	0.0	universidade-metodista-de-piracicaba
+Universidade of Sao Paulo, Faculty of Philosophy, Languages and Literature, and Human Sciences	1	4	782	782	782	0.005115089514066497	universidade-of-sao-paulo-faculty-of-philosophy-languages-and-literature-and-human-sciences
+Universita Cattolica del Sacro Cuore	1	212	520	520	520	0.4076923076923077	universita-cattolica-del-sacro-cuore
+Universita Palackeho Olomouc	1	15	0	1000	1000	0.015	universita-palackeho-olomouc
+Universitas Carolina Pragensis	1	2	0	129	129	0.015503875968992248	universitas-carolina-pragensis
+Universitat Autonoma de Barcelona	1	0	0	178	178	0.0	universitat-autonoma-de-barcelona
+Universitat Autonoma de Barcelona, Servei de Publicacions	1	0	1556	1556	1556	0.0	universitat-autonoma-de-barcelona-servei-de-publicacions
+Universitat de Barcelona	4	0	2006	3469	3469	0.0	universitat-de-barcelona
+Universitat de Lleida	1	0	7	7	7	0.0	universitat-de-lleida
+Universitat Jaume I	2	0	105	152	152	0.0	universitat-jaume-i
+Universitat Oberta de Catalunya	1	0	185	185	185	0.0	universitat-oberta-de-catalunya
+Universitat Politecnica de Catalunya	2	202	102	304	304	0.6644736842105263	universitat-politecnica-de-catalunya
+Universitat Politècnica de València	1	4	700	700	700	0.005714285714285714	universitat-politecnica-de-valencia
+Universitat Politecnica de Valencia, Servicio de Publicaciones	1	0	246	246	246	0.0	universitat-politecnica-de-valencia-servicio-de-publicaciones
+universitatea de vest	1	0	0	121	121	0.0	universitatea-de-vest
+Universitatea din Bucuresti	1	0	43	43	43	0.0	universitatea-din-bucuresti
+Universite catholique de Louvain	2	411	0	1344	1344	0.30580357142857145	universite-catholique-de-louvain
+Universite de Bordeaux	1	0	0	907	907	0.0	universite-de-bordeaux
+Universite de Bordeaux III	2	1	0	2600	2940	3.401360544217687e-4	universite-de-bordeaux-iii
+Universite de Caen	3	2	96	437	1568	0.0012755102040816326	universite-de-caen
+Universite de Lille	1	2	0	2919	2919	6.851661527920521e-4	universite-de-lille
+Universite de Lille I	1	1	1159	1159	1159	8.628127696289905e-4	universite-de-lille-i
+Universite de Toulouse-Le Mirail	1	0	80	80	80	0.0	universite-de-toulouse-le-mirail
+Universite de Toulouse. Faculte des Lettres et Sciences Humaines	1	0	0	91	91	0.0	universite-de-toulouse-faculte-des-lettres-et-sciences-humaines
+Universite des Sciences et Technologies de Lille	1	0	216	216	216	0.0	universite-des-sciences-et-technologies-de-lille
+Universite du Quebec a Trois-Rivieres, Dep. des Langues Modernes	1	477	0	0	791	0.6030341340075853	universite-du-quebec-a-trois-rivieres-dep-des-langues-modernes
+Universite Laval	2	4916	0	0	7855	0.6258434118395926	universite-laval
+Universite Laval, Departement des Litteratures	1	1081	0	0	1748	0.618421052631579	universite-laval-departement-des-litteratures
+Universite Paul Valery Montpellier III	1	0	0	146	146	0.0	universite-paul-valery-montpellier-iii
+Universiteit van die Oranje Vrystaat	1	85	0	621	621	0.13687600644122383	universiteit-van-die-oranje-vrystaat
+Universitet of Nis	1	17	1397	1397	1397	0.012168933428775949	universitet-of-nis
+Universitetsforlaget AS	3	0	13	63	63	0.0	universitetsforlaget-as
+Universitetsforlaget AS/Scandinavian University Press	2	0	0	82	82	0.0	universitetsforlaget-as-scandinavian-university-press
+Universiti Kebangsaan Malaysia	5	0	102	503	503	0.0	universiti-kebangsaan-malaysia
+Universiti Malaysia Pahang	2	4	482	482	482	0.008298755186721992	universiti-malaysia-pahang
+Universiti Putra Malaysia	1	0	0	8	8	0.0	universiti-putra-malaysia
+Universiti Sains Malaysia	5	0	70	143	143	0.0	universiti-sains-malaysia
+Universities Federation for Animal Welfare	1	258	0	308	308	0.8376623376623377	universities-federation-for-animal-welfare
+University and Research Librarians Association, ankara	1	0	2	2	2	0.0	university-and-research-librarians-association-ankara
+University Center Annapolis	1	0	192	192	192	0.0	university-center-annapolis
+University Centre of Maringa - CESUMAR	1	0	100	100	100	0.0	university-centre-of-maringa-cesumar
+University College London	1	70	0	0	71	0.9859154929577465	university-college-london
+University Federal Rural Semiarid (UFERSA)	1	0	208	208	208	0.0	university-federal-rural-semiarid-ufersa
+University Film and Video Association	1	191	0	202	202	0.9455445544554455	university-film-and-video-association
+University Library System, University of Pittsburgh	1	0	157	157	157	0.0	university-library-system-university-of-pittsburgh
+University of Adelaide	2	1062	0	515	1254	0.84688995215311	university-of-adelaide
+University of Agricultural Sciences and Veterinary Medicine	1	2	576	576	576	0.003472222222222222	university-of-agricultural-sciences-and-veterinary-medicine
+University of Alberta	1	0	925	925	925	0.0	university-of-alberta
+University of Alicante	2	0	0	715	715	0.0	university-of-alicante
+University of Alicante. Faculty of Education	1	6	554	554	554	0.010830324909747292	university-of-alicante-faculty-of-education
+University of Almeria	1	0	0	78	78	0.0	university-of-almeria
+University of Antwerp	1	1	129	129	129	0.007751937984496124	university-of-antwerp
+University of Arkansas	1	127	0	138	138	0.9202898550724637	university-of-arkansas
+University of Auckland	1	13	0	83	83	0.1566265060240964	university-of-auckland
+University of Belgrade	5	164	784	796	881	0.18615209988649262	university-of-belgrade
+University of Benin	2	672	1648	1737	1737	0.38687392055267705	university-of-benin
+University of Bialystok	2	138	501	151	501	0.2754491017964072	university-of-bialystok
+University of Birmingham	1	0	0	558	558	0.0	university-of-birmingham
+University Of Brawijaya	1	0	0	230	230	0.0	university-of-brawijaya
+University of British Columbia	1	11713	0	11726	11726	0.9988913525498891	university-of-british-columbia
+University of Bucharest	1	5	85	85	85	0.058823529411764705	university-of-bucharest
+University of Calgary Press	1	554	0	582	582	0.9518900343642611	university-of-calgary-press
+University of California	1	0	0	1373	1373	0.0	university-of-california
+University of California eScholarship Repository	1	0	36	36	36	0.0	university-of-california-escholarship-repository
+University of California Press	27	66680	2093	102854	105175	0.633990967435227	university-of-california-press
+University of Cape Town	1	0	0	31	31	0.0	university-of-cape-town
+University of Chicago Press	55	164907	1123	336277	358046	0.4605748981974383	university-of-chicago-press
+University of Chicago, Department of Computer Science	1	1	0	212	212	0.0047169811320754715	university-of-chicago-department-of-computer-science
+University of Colorado	2	3032	0	1367	3091	0.9809123261080557	university-of-colorado
+University of Defence	1	0	0	12	12	0.0	university-of-defence
+University of Dhaka	1	2	343	343	343	0.0058309037900874635	university-of-dhaka
+University of Florida	2	0	0	0	1136	0.0	university-of-florida
+University of Ghana	1	0	0	194	194	0.0	university-of-ghana
+University of Granada, Department of Hydrogeology	1	128	0	0	128	1.0	university-of-granada-department-of-hydrogeology
+University of Hawaii Press	12	4282	322	10209	10819	0.39578519271651724	university-of-hawaii-press
+University of Illinois	1	0	1927	1927	1927	0.0	university-of-illinois
+University of Illinois Press	8	21194	0	21092	22657	0.9354283444410116	university-of-illinois-press
+University of Ioannina	1	897	904	904	904	0.9922566371681416	university-of-ioannina
+University of Iowa	1	0	0	1102	1102	0.0	university-of-iowa
+University of Jordan	2	0	0	339	339	0.0	university-of-jordan
+University of Kansas	1	0	0	86	86	0.0	university-of-kansas
+University of Kansas Department of Slavic Languages and Literatures	1	0	0	117	117	0.0	university-of-kansas-department-of-slavic-languages-and-literatures
+University of Kragujevac	1	55	229	229	229	0.24017467248908297	university-of-kragujevac
+University of Kragujevac, Faculty of Science	2	6	0	452	452	0.01327433628318584	university-of-kragujevac-faculty-of-science
+University of Ljubljana	3	71	301	699	699	0.10157367668097282	university-of-ljubljana
+University of London	1	134	0	0	134	1.0	university-of-london
+University of Lueneburg, Department of Economics and Social Sciences, Research Institute on Professions	1	0	90	90	90	0.0	university-of-lueneburg-department-of-economics-and-social-sciences-research-institute-on-professions
+University of Malaya	3	123	335	89	345	0.3565217391304348	university-of-malaya
+University of Manitoba	1	26	0	184	184	0.14130434782608695	university-of-manitoba
+University of Maribor	2	26	0	349	349	0.07449856733524356	university-of-maribor
+University of Massachusetts	1	313	0	439	439	0.7129840546697038	university-of-massachusetts
+University of Medicine	1	212	264	264	264	0.803030303030303	university-of-medicine
+University of Miami	1	1084	0	0	1084	1.0	university-of-miami
+University of Michigan Press	1	0	496	496	496	0.0	university-of-michigan-press
+University Of Michigan, Department of Mathematics	1	122	0	683	683	0.17862371888726208	university-of-michigan-department-of-mathematics
+University of Minnesota	1	0	205	205	205	0.0	university-of-minnesota
+University of Minnesota Press	4	1086	0	1761	1761	0.616695059625213	university-of-minnesota-press
+University of Missouri at Columbia	1	39	0	4068	4068	0.009587020648967551	university-of-missouri-at-columbia
+University of Montreal	1	17	26	26	26	0.6538461538461539	university-of-montreal
+University of Murcia	2	0	81	268	268	0.0	university-of-murcia
+University of Naples Federico II	1	0	402	402	402	0.0	university-of-naples-federico-ii
+University of Nebraska Press	5	1993	0	2521	4225	0.4717159763313609	university-of-nebraska-press
+University of New Mexico	2	1870	0	3356	4370	0.4279176201372998	university-of-new-mexico
+University of New South Wales	1	45	0	0	45	1.0	university-of-new-south-wales
+University of Newcastle	1	522	0	0	522	1.0	university-of-newcastle
+University of Nis	3	88	220	220	220	0.4	university-of-nis
+University of North Carolina Press	1	55	0	866	866	0.06351039260969978	university-of-north-carolina-press
+University of Notre Dame	1	8238	0	8246	8246	0.9990298326461314	university-of-notre-dame
+University of Notre Dame, Law School	1	884	0	892	892	0.9910313901345291	university-of-notre-dame-law-school
+University of Novi Sad	2	206	277	752	752	0.27393617021276595	university-of-novi-sad
+University of Occupational and Environmental Health	1	0	0	207	207	0.0	university-of-occupational-and-environmental-health
+University of Oklahoma	1	28406	0	28759	28759	0.9877255815570778	university-of-oklahoma
+University of Ostrava	1	0	70	70	70	0.0	university-of-ostrava
+University of Pennsylvania Law Review	1	2795	0	2795	2795	1.0	university-of-pennsylvania-law-review
+University of Pennsylvania Press	3	5192	0	5977	5977	0.8686632089677095	university-of-pennsylvania-press
+University of Pittsburgh Press	3	1127	0	319	1677	0.6720333929636255	university-of-pittsburgh-press
+University of Pretoria	2	740	0	9	750	0.9866666666666667	university-of-pretoria
+University of Puerto Rico	1	224	0	0	228	0.9824561403508771	university-of-puerto-rico
+University of Queensland	1	0	0	1641	1641	0.0	university-of-queensland
+University of Rhode Island	1	322	0	1145	1145	0.2812227074235808	university-of-rhode-island
+University of Rijeka, Faculty of Tourism and Hospitality Management, Opatija	1	0	22	22	22	0.0	university-of-rijeka-faculty-of-tourism-and-hospitality-management-opatija
+University of Salento	1	0	25	25	25	0.0	university-of-salento
+University of Sao Paulo, Ribeirao Preto College of Nursing Organisation	1	1	140	140	140	0.007142857142857143	university-of-sao-paulo-ribeirao-preto-college-of-nursing-organisation
+University of Science and Technology Beijing	2	1628	0	1254	1651	0.9860690490611751	university-of-science-and-technology-beijing
+University of Sevilla, School of Architecture	1	0	178	178	178	0.0	university-of-sevilla-school-of-architecture
+University of South Bohemia	1	131	0	140	140	0.9357142857142857	university-of-south-bohemia
+University of Southern California	1	264	0	0	264	1.0	university-of-southern-california
+University of Split	1	0	0	166	166	0.0	university-of-split
+University of Ss Kiril and Metodij	1	54	424	0	424	0.12735849056603774	university-of-ss-kiril-and-metodij
+University of St. Thomas	1	0	0	20	20	0.0	university-of-st-thomas
+University of Stellenbosch	2	0	392	635	635	0.0	university-of-stellenbosch
+University of Suceava	1	6	647	647	647	0.00927357032457496	university-of-suceava
+University of Surrey	1	0	347	347	347	0.0	university-of-surrey
+University of Sydney	1	0	0	48	48	0.0	university-of-sydney
+University of Technology Sydney ePress	1	0	0	0	305	0.0	university-of-technology-sydney-epress
+University of Technology, Sydney	1	13	0	314	314	0.041401273885350316	university-of-technology-sydney
+University of Texas Press	5	767	0	768	2560	0.299609375	university-of-texas-press
+University of the Basque Country Press	1	98	0	1433	1433	0.06838799720865317	university-of-the-basque-country-press
+University of the West Indies	1	0	1562	1562	1562	0.0	university-of-the-west-indies
+University of Tokyo Press	3	1072	0	0	2139	0.501168770453483	university-of-tokyo-press
+University of Toronto Press	27	31576	2347	39021	46598	0.6776256491694923	university-of-toronto-press
+University of Tras-os-Montes and Alto Douro	1	119	421	421	421	0.2826603325415677	university-of-tras-os-montes-and-alto-douro
+University of Tulsa	1	758	0	807	807	0.9392812887236679	university-of-tulsa
+University of Utah	1	6050	0	0	6050	1.0	university-of-utah
+University of Veszprem	1	5	0	0	16	0.3125	university-of-veszprem
+University of Veterinary and Pharmaceutical Sciences	1	497	1827	1827	1827	0.2720306513409962	university-of-veterinary-and-pharmaceutical-sciences
+University of Wales Press	4	54	0	132	589	0.09168081494057725	university-of-wales-press
+University of Warsaw	1	52	130	130	130	0.4	university-of-warsaw
+University of Warwick	1	215	0	944	944	0.2277542372881356	university-of-warwick
+University of Windsor	1	0	736	736	736	0.0	university-of-windsor
+University of Wisconsin Press	10	10815	0	14867	15884	0.6808738353059682	university-of-wisconsin-press
+University of Wollongong	1	0	122	122	122	0.0	university-of-wollongong
+University of Wyoming	2	184	0	155	206	0.8932038834951457	university-of-wyoming
+University of York	1	0	545	545	545	0.0	university-of-york
+University of Zagreb	12	219	1250	1766	1766	0.12400906002265005	university-of-zagreb
+University of Zimbabwe Publications	1	0	0	0	92	0.0	university-of-zimbabwe-publications
+University Park Press	1	972	0	0	972	1.0	university-park-press
+University Ss Kiril and Metodij, Faculty of Veterinary Medicine	1	33	101	101	101	0.32673267326732675	university-ss-kiril-and-metodij-faculty-of-veterinary-medicine
+Univerza v Ljubljani	3	323	792	1325	1325	0.24377358490566037	univerza-v-ljubljani
+Univerzita Komenskeho	1	63	63	0	63	1.0	univerzita-komenskeho
+Univerzitet u Novom Sadu	1	7	355	355	355	0.01971830985915493	univerzitet-u-novom-sadu
+Univerzitet u Tuzli	1	0	0	67	67	0.0	univerzitet-u-tuzli
+Uniwersytet Marii Curie-Sklodowskiej	2	0	0	23	88	0.0	uniwersytet-marii-curie-sklodowskiej
+Uniwersytet Medyczny w Lodzi	1	0	0	4	4	0.0	uniwersytet-medyczny-w-lodzi
+Uniwersytet Medyczny w Lublinie	1	14	182	182	182	0.07692307692307693	uniwersytet-medyczny-w-lublinie
+UNLV School of Nursing	1	0	0	24	24	0.0	unlv-school-of-nursing
+Unversiteit van Tilburg	2	0	0	0	34	0.0	unversiteit-van-tilburg
+UP Print LLC	1	1	1279	1279	1279	7.818608287724785e-4	up-print-llc
+UQ Business School, The University of Queensland	1	0	606	606	606	0.0	uq-business-school-the-university-of-queensland
+Ural Federal University	3	1	56	445	445	0.0022471910112359553	ural-federal-university
+Urban Planning Institute of the Republic of Slovenia	1	2	773	773	773	0.00258732212160414	urban-planning-institute-of-the-republic-of-slovenia
+Urban und Vogel Medien und Medizin Verlagsgesellschaft mbH	12	20949	0	14683	21085	0.9935499170026085	urban-und-vogel-medien-und-medizin-verlagsgesellschaft-mbh
+Urednistvo Casopisa	1	0	29	29	29	0.0	urednistvo-casopisa
+Urednistvo Tekstilec	1	0	0	101	101	0.0	urednistvo-tekstilec
+Urogynaecologia International Journal	1	0	0	95	95	0.0	urogynaecologia-international-journal
+UroToday Inc.	1	0	0	0	94	0.0	urotoday-inc
+US Department of Health and Human Services	2	9321	22234	22234	22234	0.41922281190968785	us-department-of-health-and-human-services
+US National Marine Fisheries Services	2	80	0	198	198	0.40404040404040403	us-national-marine-fisheries-services
+US National Research Council	1	11980	0	16924	16924	0.7078704797920113	us-national-research-council
+Ustav Dejin Umeni AV CR	1	0	0	14	14	0.0	ustav-dejin-umeni-av-cr
+UTS Press	1	0	85	85	85	0.0	uts-press
+V. A. Negovsky Research Institute of General Reanimatology	1	0	0	938	938	0.0	v-a-negovsky-research-institute-of-general-reanimatology
+V.H. Winston and Sons, Inc.	3	1755	0	0	1759	0.9977259806708357	v-h-winston-and-sons-inc
+Vaillant Carmanne	3	3998	0	0	3998	1.0	vaillant-carmanne
+Van Zuiden Communications B.V.	1	1660	0	1671	1671	0.9934171154997008	van-zuiden-communications-b-v
+Vandenhoeck and Ruprecht	8	33	0	4110	4110	0.008029197080291971	vandenhoeck-and-ruprecht
+Vandenhoeck and Ruprecht GmbH and Co. KG	2	0	0	566	566	0.0	vandenhoeck-and-ruprecht-gmbh-and-co-kg
+VBRI Press	1	52	907	0	907	0.05733186328555678	vbri-press
+Veleuciliste u Dubrovniku Collegium Ragusinum	1	12	131	131	131	0.0916030534351145	veleuciliste-u-dubrovniku-collegium-ragusinum
+Verlag Barbara Budrich	1	0	0	61	61	0.0	verlag-barbara-budrich
+Verlag C.H. Beck oHG	1	0	0	320	320	0.0	verlag-c-h-beck-ohg
+Verlag der Osterreichischen Akademie der Wissenschaften	5	112	0	805	896	0.125	verlag-der-osterreichischen-akademie-der-wissenschaften
+Verlag Eugen Ulmer	2	2	0	84	168	0.011904761904761904	verlag-eugen-ulmer
+Verlag Gehlen	1	64	0	0	236	0.2711864406779661	verlag-gehlen
+Verlag Hans Huber AG	10	1642	0	15354	15354	0.10694281620424645	verlag-hans-huber-ag
+Verlag Klett-Cotta	3	0	0	55	92	0.0	verlag-klett-cotta
+Verlag Paul Parey	2	9124	0	0	9154	0.9967227441555604	verlag-paul-parey
+Verlag Stahleisen GmbH	1	189	0	0	1894	0.09978880675818373	verlag-stahleisen-gmbh
+Verlag Westfaelisches Dampfboot	1	0	0	0	118	0.0	verlag-westfaelisches-dampfboot
+Veterinary World	1	340	1330	1330	1330	0.2556390977443609	veterinary-world
+Via Medica	16	77	3285	5076	5076	0.015169424743892828	via-medica
+Vibromechanika	1	0	0	426	426	0.0	vibromechanika
+Vice-Presidency for Research and Graduate, University of Caldas	1	0	0	22	22	0.0	vice-presidency-for-research-and-graduate-university-of-caldas
+Vicenza Pediatria Medica E Chirurgica	1	0	123	123	123	0.0	vicenza-pediatria-medica-e-chirurgica
+Victoria University	1	0	511	0	511	0.0	victoria-university
+Vilniaus pedagoginis universitetas	1	0	184	184	184	0.0	vilniaus-pedagoginis-universitetas
+Vilniaus Universiteto Leidykla	1	0	0	98	98	0.0	vilniaus-universiteto-leidykla
+Vilnius Gediminas Technical University	3	143	400	722	890	0.16067415730337078	vilnius-gediminas-technical-university
+VINCA Institute of Nuclear Sciences	2	704	2842	2842	2842	0.24771287825475016	vinca-institute-of-nuclear-sciences
+Vinnytsia National Technical University	1	0	0	26	26	0.0	vinnytsia-national-technical-university
+Virginia Law Review Association	1	9738	0	9738	9738	1.0	virginia-law-review-association
+Virginia Military Institute	1	2793	0	0	2793	1.0	virginia-military-institute
+Virginia Polytechnic Institute & State University	1	13	0	0	13	1.0	virginia-polytechnic-institute-state-university
+Virtual Explorer Pty. Ltd.	1	1	0	0	269	0.0037174721189591076	virtual-explorer-pty-ltd
+Virtus Interpress	3	0	0	0	2830	0.0	virtus-interpress
+"Visuomenine organizacija ""LOGOS"""	1	0	0	23	23	0.0	visuomenine-organizacija-logos
+Vitebsk State Medical University	1	0	381	381	381	0.0	vitebsk-state-medical-university
+Vittorio Klostermann	5	744	0	2573	2664	0.27927927927927926	vittorio-klostermann
+Vizja Press and IT Limited	2	20	530	530	530	0.03773584905660377	vizja-press-and-it-limited
+Vlex	1	0	0	0	433	0.0	vlex
+VS Verlag fur Sozialwissenschaften	4	3997	0	4620	4620	0.8651515151515151	vs-verlag-fur-sozialwissenschaften
+VSB-Technical University of Ostrava	1	0	407	407	407	0.0	vsb-technical-university-of-ostrava
+Vserossiiskoe Obshchestvo Kardiologov	1	0	0	232	232	0.0	vserossiiskoe-obshchestvo-kardiologov
+Vydavatel'stvo Slovenkej Akademie Vied/Veda Publishing House of the Slovak Academy of Sciences	1	4	0	237	237	0.016877637130801686	vydavatelstvo-slovenkej-akademie-vied-veda-publishing-house-of-the-slovak-academy-of-sciences
+Vydavatelstvi Karolinum	2	2	255	331	331	0.006042296072507553	vydavatelstvi-karolinum
+Vysoka Skola Ekonomicka	2	0	0	1645	1645	0.0	vysoka-skola-ekonomicka
+Vytautas Magnus University	1	47	127	127	127	0.3700787401574803	vytautas-magnus-university
+W J G Press	1	479	16324	16324	16324	0.02934329821122274	w-j-g-press
+W W F Verlagsgesellschaft mbH	1	1	0	270	270	0.003703703703703704	w-w-f-verlagsgesellschaft-mbh
+W. Kohlhammer GmbH	1	7	0	0	7	1.0	w-kohlhammer-gmbh
+Wageningen Academic Publishers	5	430	0	1669	1669	0.2576393049730378	wageningen-academic-publishers
+Wageningen Pers	1	20	0	225	225	0.08888888888888889	wageningen-pers
+Walsh Medical Media	1	59	0	301	301	0.19601328903654486	walsh-medical-media
+Walter de Gruyter	371	327439	26382	407405	443663	0.738035400743357	walter-de-gruyter
+Warburg Institute, University of London	1	1282	0	0	1282	1.0	warburg-institute-university-of-london
+Warsaw University	2	59	166	194	194	0.30412371134020616	warsaw-university
+Warsaw University of Technology	1	31	177	177	177	0.1751412429378531	warsaw-university-of-technology
+Washington State University Press	2	986	0	478	1016	0.9704724409448819	washington-state-university-press
+Water Environment Federation	1	3046	0	3433	3433	0.8872706087969706	water-environment-federation
+Water Research Commission	1	222	1220	1220	1220	0.1819672131147541	water-research-commission
+Water Science and Engineering	1	102	112	112	112	0.9107142857142857	water-science-and-engineering
+Waterbird Society	2	2308	0	1469	2359	0.9783806697753286	waterbird-society
+Waxmann Verlag GMBH	1	268	0	0	268	1.0	waxmann-verlag-gmbh
+Wayne State University Press	8	1136	0	2851	2851	0.3984566818660119	wayne-state-university-press
+West African College of Physicians	1	1	0	0	522	0.0019157088122605363	west-african-college-of-physicians
+West Chester State College	1	84	0	776	776	0.10824742268041238	west-chester-state-college
+West Virginia State Medical Association	1	0	0	23	23	0.0	west-virginia-state-medical-association
+West Virginia University	1	72	0	681	681	0.10572687224669604	west-virginia-university
+Westerdijk Fungal Biodiversity Institute	1	279	282	282	282	0.9893617021276596	westerdijk-fungal-biodiversity-institute
+Western Academic & Specialist Press Ltd	1	285	0	0	300	0.95	western-academic-specialist-press-ltd
+Western Academic Publishers	1	0	0	2131	2131	0.0	western-academic-publishers
+Western Illinois University	3	965	0	0	1530	0.630718954248366	western-illinois-university
+Western Speech Communication Association	1	538	0	0	540	0.9962962962962963	western-speech-communication-association
+Westminster Publications Inc.	1	7	0	0	7	1.0	westminster-publications-inc
+Weston Medical Publishing, LLC	1	0	0	254	254	0.0	weston-medical-publishing-llc
+White Horse Press	3	1388	0	1563	1563	0.8880358285348688	white-horse-press
+Whiting & Birch Ltd.	2	0	0	0	345	0.0	whiting-birch-ltd
+Whiting and Birch	2	0	0	0	188	0.0	whiting-and-birch
+Whurr Publishers Ltd.	4	1258	0	379	1283	0.9805144193296961	whurr-publishers-ltd
+Wichtig Publishing	11	878	0	5198	5437	0.16148611366562443	wichtig-publishing
+Widner University	1	33	0	232	232	0.14224137931034483	widner-university
+Wilding & Son	1	56	0	0	56	1.0	wilding-son
+Wildlife Disease Association	1	5760	0	5803	5803	0.9925900396346717	wildlife-disease-association
+Wildlife Information & Liaison Development Society	1	4	0	1332	1332	0.003003003003003003	wildlife-information-liaison-development-society
+Wiley-Blackwell	1639	5786361	97617	5468759	6107661	0.947393936893354	wiley-blackwell
+Wilfrid Laurier University Press	2	136	0	1292	2131	0.06381980290943219	wilfrid-laurier-university-press
+Wilson Ornithological Society	2	2018	0	1467	2043	0.9877630934899657	wilson-ornithological-society
+Wissenschaftliche Gesellschaft fur Technische Logistik	1	0	0	39	39	0.0	wissenschaftliche-gesellschaft-fur-technische-logistik
+Wistar Institute of Anatomy and Biology	1	2575	0	0	2582	0.9972889233152595	wistar-institute-of-anatomy-and-biology
+WIT Press	5	3	0	1047	1140	0.002631578947368421	wit-press
+Wolters Kluwer Health	426	1481291	84234	1803229	1864435	0.7944986014529871	wolters-kluwer-health
+Wolters-Noordhoff	1	396	0	0	396	1.0	wolters-noordhoff
+Women's Health and Action Research Centre	1	377	0	377	377	1.0	womens-health-and-action-research-centre
+WordPerfect Pub. Corp.	1	647	0	0	647	1.0	wordperfect-pub-corp
+World Association for Laser Therapy	1	1	0	887	887	0.0011273957158962795	world-association-for-laser-therapy
+World Health Organization	2	1006	234	2518	2518	0.3995234312946783	world-health-organization
+World Informations Syndicate	1	0	0	345	345	0.0	world-informations-syndicate
+World Scientific	107	126011	891	129938	131835	0.9558235673379604	world-scientific
+World Wide Web Publications (P) India	1	1	0	0	1595	6.269592476489029e-4	world-wide-web-publications-p-india
+Worldwide Center of Mathematics	1	1	0	188	188	0.005319148936170213	worldwide-center-of-mathematics
+WormBook	1	6	0	200	200	0.03	wormbook
+Wroclaw Medical University, Polish Stomatological Association	1	0	90	90	90	0.0	wroclaw-medical-university-polish-stomatological-association
+Wroclaw University of Technology	1	0	6	6	6	0.0	wroclaw-university-of-technology
+Wuhan Daxue	1	2911	0	2936	2936	0.9914850136239782	wuhan-daxue
+Wuhan University of Technology	1	2858	0	2903	2903	0.9844987943506717	wuhan-university-of-technology
+WWF-U.S. Primate Program	1	158	0	158	158	1.0	wwf-u-s-primate-program
+Wydawnictwo Akademii Rolniczej w Poznaniu	1	9	124	124	124	0.07258064516129033	wydawnictwo-akademii-rolniczej-w-poznaniu
+Wydawnictwo Continuo	1	0	126	126	126	0.0	wydawnictwo-continuo
+Wydawnictwo Medyczne Sanmedica Sp	1	7	0	0	464	0.015086206896551725	wydawnictwo-medyczne-sanmedica-sp
+Wydawnictwo Medyczne Urban i Partner	3	2147	1326	2536	2536	0.8466088328075709	wydawnictwo-medyczne-urban-i-partner
+Wydawnictwo Naukowe INVIT	1	34	63	63	63	0.5396825396825397	wydawnictwo-naukowe-invit
+Wydawnictwo Naukowe P W N SA	1	81	0	0	168	0.48214285714285715	wydawnictwo-naukowe-p-w-n-sa
+Wydawnictwo Naukowe Uniwersytetu Mikolaja Kopernika	2	0	0	317	317	0.0	wydawnictwo-naukowe-uniwersytetu-mikolaja-kopernika
+Wydawnictwo Naukowe WNPiD UAM	1	0	0	221	221	0.0	wydawnictwo-naukowe-wnpid-uam
+Wydawnictwo SIGMA	4	2	0	2393	2482	8.058017727639e-4	wydawnictwo-sigma
+Wydawnictwo Uniwersytetu	1	53	170	170	170	0.31176470588235294	wydawnictwo-uniwersytetu
+Xi'an Jiaotong University	1	402	411	411	411	0.9781021897810219	xian-jiaotong-university
+Yale French Studies	1	1555	0	0	1555	1.0	yale-french-studies
+Yale Journal Co., Inc.	1	16101	0	16101	16101	1.0	yale-journal-co-inc
+Yale University Press	1	2355	0	0	2355	1.0	yale-university-press
+Yamaguchi Kenritsu Ika Daigaku Igakkai	1	0	0	0	269	0.0	yamaguchi-kenritsu-ika-daigaku-igakkai
+Yamashina Chourui Kenkyuujo	1	0	0	233	233	0.0	yamashina-chourui-kenkyuujo
+Yao xue fu wu yu yan jiu za zhi she	1	0	0	824	824	0.0	yao-xue-fu-wu-yu-yan-jiu-za-zhi-she
+Yerkure Tanitim ve Yayincilik A.S.	1	124	0	263	263	0.4714828897338403	yerkure-tanitim-ve-yayincilik-a-s
+Yijun Institute of International Law	1	20	0	175	175	0.11428571428571428	yijun-institute-of-international-law
+ying yong guang xue bian ji bu	1	0	0	278	278	0.0	ying-yong-guang-xue-bian-ji-bu
+Yonsei University	1	18	4276	4276	4276	0.00420954162768943	yonsei-university
+Yukawa Institute for Theoretical Physics	1	3894	0	0	4743	0.8209993674889311	yukawa-institute-for-theoretical-physics
+Yuzuncu Yyl University	1	0	52	52	52	0.0	yuzuncu-yyl-university
+Zagreb Academy of Music	1	613	0	613	613	1.0	zagreb-academy-of-music
+Zaheer Babar	1	18	0	0	18	1.0	zaheer-babar
+Zaklad Narodowy imienia Ossolinskich	1	210	369	369	369	0.5691056910569106	zaklad-narodowy-imienia-ossolinskich
+Zalozba Z R C	1	0	0	389	389	0.0	zalozba-z-r-c
+Zalozba Z R C (Scientific Research Centre Publishing)	1	0	0	278	278	0.0	zalozba-z-r-c-scientific-research-centre-publishing
+Zdravstveni Centar Rijeka	1	0	0	0	49	0.0	zdravstveni-centar-rijeka
+Zhejiang Daxue	1	11	0	0	847	0.012987012987012988	zhejiang-daxue
+Zhejiang University Press	3	3911	0	3463	3962	0.9871277132761231	zhejiang-university-press
+Zhongguo Dianzi Xuehui	1	262	0	383	383	0.6840731070496083	zhongguo-dianzi-xuehui
+Zhongguo Kexue Zazhishe/Science in China Press	13	29810	0	12013	31065	0.9596008369547723	zhongguo-kexue-zazhishe-science-in-china-press
+Zhongguo Kexueyan Ganguang Huaxue Yanjiusuo	1	0	0	1382	1382	0.0	zhongguo-kexueyan-ganguang-huaxue-yanjiusuo
+Zhongguo Kexueyuan	2	238	0	685	685	0.34744525547445254	zhongguo-kexueyuan
+Zhongguo Kuangye Daxue	1	281	0	0	281	1.0	zhongguo-kuangye-daxue
+Zhongguo Zhongyi Yanjiuyuan	1	0	0	5549	5549	0.0	zhongguo-zhongyi-yanjiuyuan
+Zhonghua Minguo ma zui yi xue hui	1	406	0	407	407	0.9975429975429976	zhonghua-minguo-ma-zui-yi-xue-hui
+Zhonghua Minguo Wuli Xuehui	1	192	218	218	218	0.8807339449541285	zhonghua-minguo-wuli-xuehui
+Zhonghua Yixeuehui Zazhishe/Chinese Medical Association Publishing House	1	3	1374	1374	1374	0.002183406113537118	zhonghua-yixeuehui-zazhishe-chinese-medical-association-publishing-house
+Zhongnan Gongye Daxue/Central South University of Technology	1	2290	0	0	2290	1.0	zhongnan-gongye-daxue-central-south-university-of-technology
+Zhongshan Daxue Xue/Zhongshan University	1	10	0	1863	1863	0.005367686527106817	zhongshan-daxue-xue-zhongshan-university
+Zoo Outreach Organisation	1	0	0	0	7	0.0	zoo-outreach-organisation
+Zoological Society of Japan	1	2861	0	3134	3134	0.9128908742820676	zoological-society-of-japan
+Zoological Society of Pakistan	1	0	0	92	92	0.0	zoological-society-of-pakistan
+Zwiazku Zawodowego Pracownikow Sluzby Zdrowia	1	0	0	218	218	0.0	zwiazku-zawodowego-pracownikow-sluzby-zdrowia


### PR DESCRIPTION
Refs https://github.com/greenelab/scihub/pull/45#discussion_r153051504

@arielsvn does this look good for removing sluggify logic from https://github.com/greenelab/scihub/pull/45? Publisher coverage is now in a separate file `publisher-coverage.tsv` rather than `coverage-by-category.tsv`. This may require some refactoring, but should simplify the frontend manipulation required?